### PR TITLE
Improve doc

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -9,7 +9,8 @@ and decisions.
   Data Point model, MQTT reporting/downlink. ADRs: `modules/iot-client/docs/adr/`.
 - [RTC TCP Client](./modules/rtc-tcp-client/CONTEXT.md) — device ↔ Tuya AI Foundation
   real-time audio/video/text transport: the Connection, Session, Event lifecycle and the
-  binary packet/frame framing. ADRs: `modules/rtc-tcp-client/docs/adr/`.
+  binary packet/frame framing. Design decisions live in CONTEXT.md and the callback-contract
+  block in `modules/rtc-tcp-client/include/tuya_ai.h`.
 - [Tuya BLE](./modules/tuya-ble/CONTEXT.md) — device ↔ app BLE provisioning: advertising,
   the pairing handshake, and WiFi-credential delivery.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | RTC TCP Client | `tuya_ai.h` | tRTC(tuya自研RTC协议) TCP 实现，开源实现，PAL 可移植 |
 | RTC Client | `stm_open.h` | tRTC(tuya自研RTC协议) UDP 实现，预编译静态库形式 |
 | IoT Client | `iot_client.h`、`iot_dp.h`、`iot_ota.h` | 设备激活、MQTT 连接、会话令牌获取；数据点（DP）管理（schema 校验 / 缓存 / 上下行 / 持久化）；OTA 固件升级（云端协议） |
-| Tuya BLE | `tuya_ble_nimble.h` | BLE 蓝牙配网（ESP-IDF） |
+| Tuya BLE | `tuya_ble_prov.h` | BLE 蓝牙配网（ESP-IDF） |
 
 ## 环境要求
 
@@ -44,30 +44,30 @@ cmake .. && make
 
 ## 运行示例
 
-编译 POSIX 平台示例：
+编译 POSIX 平台示例（示例是独立工程，请使用单独的构建目录，避免与上面 SDK 构建的 `build/` 缓存冲突）：
 
 ```sh
-cmake -S examples/posix -B build
-cmake --build build
+cmake -S examples/posix -B build-examples
+cmake --build build-examples
 ```
 
 运行：
 
 ```sh
 # 语音/文本聊天（RTC TCP Client）
-./build/tai_text_chat_demo
+./build-examples/tai_text_chat_demo
 
 # 设备扫码配网
-./build/scan_by_device_pair_demo
+./build-examples/scan_by_device_pair_demo
 
 # App 扫码配网
-./build/scan_by_app_pair_demo
+./build-examples/scan_by_app_pair_demo
 
 # 设备数据点（DP）管理
-./build/dp_management_demo
+./build-examples/dp_management_demo
 
 # OTA 固件升级（云端协议）
-./build/ota_demo
+./build-examples/ota_demo
 ```
 
 ## 项目结构
@@ -91,6 +91,6 @@ docs-site/            # 文档站点
 
 本项目整体基于 [Apache License 2.0](LICENSE) 开源。
 
-**例外**：`modules/rtc-client/` 模块**不开源**，其中的预编译静态库（`libstm.a`）及配套头文件为 Tuya Inc. 专有资产。客户可自由使用、复制、分发该模块，包括嵌入到硬件产品中（无论是否结合 agentic-kit 使用），唯一限制是**不得对预编译库进行逆向工程、反编译或反汇编**。详见 [modules/rtc-client/LICENSE](modules/rtc-client/LICENSE)。
+**例外**：`modules/rtc-client/` 模块**不开源**，其中的预编译静态库（`libstm.a`）及配套头文件为 Tuya Inc. 专有资产。客户可自由使用、复制、修改、合并、发布、分发该模块，包括嵌入到硬件产品中（无论是否结合 agentic-kit 使用），唯一限制是**不得对预编译库进行逆向工程、反编译或反汇编**。详见 [modules/rtc-client/LICENSE](modules/rtc-client/LICENSE)。
 
 

--- a/README_en.md
+++ b/README_en.md
@@ -19,7 +19,7 @@ Multimodal device-side SDK for connecting smart hardware to the Tuya AI platform
 | RTC TCP Client | `tuya_ai.h` | tRTC (Tuya RTC protocol), TCP implementation, fully open sourced with PAL portability |
 | RTC Client | `stm_open.h` | tRTC (Tuya RTC protocol), UDP implementation, pre-compiled static library |
 | IoT Client | `iot_client.h`, `iot_dp.h`, `iot_ota.h` | Device activation, MQTT, session token; Data Point (DP) management (schema validation / cache / up- & downlink / persistence); OTA firmware upgrade (cloud protocol) |
-| Tuya BLE | `tuya_ble_nimble.h` | BLE provisioning (ESP-IDF) |
+| Tuya BLE | `tuya_ble_prov.h` | BLE provisioning (ESP-IDF) |
 
 ## Prerequisites
 
@@ -42,30 +42,30 @@ cmake .. && make
 ```
 ## Run Examples
 
-Build the posix examples:
+Build the posix examples (a standalone project — use a separate build directory so it does not clash with the SDK's `build/` cache above):
 
 ```sh
-cmake -S examples/posix -B build
-cmake --build build
+cmake -S examples/posix -B build-examples
+cmake --build build-examples
 ```
 
 Then run:
 
 ```sh
 # Voice/text chat (RTC TCP Client)
-./build/tai_text_chat_demo
+./build-examples/tai_text_chat_demo
 
 # Device scan QR pairing
-./build/scan_by_device_pair_demo
+./build-examples/scan_by_device_pair_demo
 
 # App scan QR pairing
-./build/scan_by_app_pair_demo
+./build-examples/scan_by_app_pair_demo
 
 # Device data point (DP) management
-./build/dp_management_demo
+./build-examples/dp_management_demo
 
 # OTA firmware upgrade (cloud protocol)
-./build/ota_demo
+./build-examples/ota_demo
 ```
 
 ## Project Structure

--- a/docs-site/docs/architecture.mdx
+++ b/docs-site/docs/architecture.mdx
@@ -74,7 +74,7 @@ Agentic-kit 是 AI 智能设备的端侧 SDK，负责设备与涂鸦云平台之
 │   │   └── libs/
 │   ├── iot-client/         # IoT 客户端（激活、MQTT、token）
 │   │   ├── include/iot_client.h
-│   │   └── libs/
+│   │   └── src/
 │   └── tuya-ble/           # BLE 配网模块
 ├── examples/
 │   ├── posix/              # macOS/Linux 示例

--- a/docs-site/docs/concepts.md
+++ b/docs-site/docs/concepts.md
@@ -84,8 +84,10 @@ tRTC（Tuya RTC）是涂鸦自研的实时通信协议。Agentic-kit 提供两�
 | rtc-client（`stm_open_*`） | UDP | 预编译静态库 | 快速集成、弱网场景 |
 
 设备通过 tRTC 通道发送语音/图片/文本给云端 AI，接收 AI 返回的 TTS 音频、文字
-回复、以及 MCP 工具调用指令。这条通道由 SDK 内部管理 TLS 加密、心跳保活、
-断线重连，你只需实现回调处理业务逻辑。
+回复、以及 MCP 工具调用指令。这条通道由 SDK 内部管理 TLS 加密与心跳保活，你只需
+实现回调处理业务逻辑。断线重连两种实现有差异：rtc-client 内部有恢复重连
+（Recovering）机制；rtc-tcp-client 则需要应用在收到 `on_disconnect` 回调后自行
+重新调用 `tai_connect()`（注意不要在回调内直接调用，详见 [FAQ](./faq)）。
 
 **了解更多**：[RTC TCP Client 参考](./reference/rtc-tcp-client) | [RTC Client 参考](./reference/rtc-client)
 
@@ -122,7 +124,7 @@ SDK 管理数据点的**本地缓存**和**上下行通信**：
 在上面运行。
 
 Agentic-kit 不直接调用操作系统的 API，而是通过 PAL 间接调用。这使得 SDK 可以
-运行在任何平台上——你只需为你的芯片/操作系统实现约 10 个 PAL 接口：
+运行在任何平台上——你只需为你的芯片/操作系统实现 14 个 PAL 接口：
 
 | 接口类别 | 函数 | 说明 |
 |----------|------|------|

--- a/docs-site/docs/guides/porting-to-new-platform.md
+++ b/docs-site/docs/guides/porting-to-new-platform.md
@@ -106,7 +106,7 @@ tai_config_t cfg = {
 | 互斥锁 | `xSemaphoreCreateRecursiveMutex` |
 | 时间 | `xTaskGetTickCount() * portTICK_PERIOD_MS` |
 
-> **注意：** `pal.h:91` 要求 `mutex_create` 返回**递归锁**，因此必须使用 `xSemaphoreCreateRecursiveMutex`（配合 `xSemaphoreTakeRecursive` / `xSemaphoreGiveRecursive`），不能用非递归的 `xSemaphoreCreateMutex`，否则会在重入加锁路径上死锁。
+> **注意：** `pal.h` 的 `mutex_create` 契约（见头文件注释）要求返回**递归锁**，因此必须使用 `xSemaphoreCreateRecursiveMutex`（配合 `xSemaphoreTakeRecursive` / `xSemaphoreGiveRecursive`），不能用非递归的 `xSemaphoreCreateMutex`，否则会在重入加锁路径上死锁。
 
 TCP 部分取决于具体的网络协议栈（lwIP、AT 指令等）。
 
@@ -116,7 +116,7 @@ TCP 部分取决于具体的网络协议栈（lwIP、AT 指令等）。
 
 | 组件 | 内存需求 | 建议分配位置 |
 |------|---------|-------------|
-| `tai_ctx_size()` | 依赖编译期缓冲配置，默认可达数百 KB | 若平台支持，可优先考虑大块外部内存（如 ESP32-S3 PSRAM） |
+| `tai_ctx_size()` | 依赖编译期缓冲配置，默认约 38 KB（调大 `TAI_FRAG_BUF_SIZE` 等缓冲后会相应增长） | 若平台支持，可优先考虑大块外部内存（如 ESP32-S3 PSRAM） |
 | TLS 工作区 | ~30 KB | PSRAM |
 | 音频发送缓冲 | ~4-8 KB | 内部 SRAM |
 | 音频接收缓冲 | ~8-16 KB | 内部 SRAM 或 PSRAM |

--- a/docs-site/docs/reference/rtc-client.md
+++ b/docs-site/docs/reference/rtc-client.md
@@ -176,6 +176,8 @@ stm_ret stm_open_session_send(stm_open_session_t *session, stm_open_data_t *data
 | union | params | 首包按类型填写 `audio_params` / `image_params` 等 |
 | `payload` | `uint8_t *` | 数据内容 |
 | `payload_length` | `uint32_t` | 数据长度 |
+| `app_data` | `char *` | 应用自定义数据（可为 NULL） |
+| `timestamp` | `uint64_t` | 时间戳，仅 video/audio/image 类型有效 |
 
 ---
 
@@ -206,6 +208,8 @@ void stm_open_session_close(stm_open_session_t *session);
 | `sample_rate` | `uint32_t` | 采样率 Hz |
 | `channels` | `uint16_t` | 声道数 |
 | `bit_depth` | `uint16_t` | 位深度 |
+| `container` | `uint16_t` | 音频容器类型 |
+| `bitrate` | `uint32_t` | 比特率 |
 | `frame_duration` | `uint16_t` | 帧时长 ms |
 | `frame_size` | `uint16_t` | 帧大小 bytes |
 
@@ -309,6 +313,6 @@ stm_open_session_send(sess, &last, 1);  // fin=1
 | 协议 | tRTC(tuya自研RTC协议)，UDP 实现 | tRTC(tuya自研RTC协议)，TCP 实现 |
 | 会话管理 | 需 session_token（从 IoT Client 获取） | 使用 device_id + local_key 直接连接 |
 | API 风格 | 通用 send/recv + data 结构体 | 类型化 API（`send_text`、`send_audio_*`） |
-| MCP 支持 | 通过 CMD 类型 | 原生 `TAI_EVT_MCP_CMD` + `tai_send_mcp_response` |
+| MCP 支持 | 无专用类型（`stm_cmd_type_e` 仅定义打断指令） | 原生 `TAI_EVT_MCP_CMD` + `tai_send_mcp_response` |
 | 平台支持 | macOS/Linux/MIPS/ARM（预编译） | 任何实现了 PAL 的平台 |
 | 适合场景 | 已有平台的快速集成 | 新项目、需要源码控制、ESP-IDF |

--- a/docs-site/docs/reference/rtc-tcp-client.md
+++ b/docs-site/docs/reference/rtc-tcp-client.md
@@ -29,6 +29,7 @@ sidebar_position: 1
 | 宏 | 值 | 说明 |
 |----|---|------|
 | `TAI_PKT_CLIENT_HELLO` | 1 | 客户端握手 |
+| `TAI_PKT_AUTHENTICATE_RESPONSE` | 3 | 服务端对 ClientHello 的鉴权结果 |
 | `TAI_PKT_PING` | 4 | 心跳请求 |
 | `TAI_PKT_PONG` | 5 | 心跳响应 |
 | `TAI_PKT_CONNECTION_CLOSE` | 6 | 连接关闭 |
@@ -148,8 +149,8 @@ sidebar_position: 1
 |------|------|------|
 | `device_id` | `const char *` | 设备 ID（配网后获得的 devid） |
 | `local_key` | `const char *` | 本地密钥（配网后获得的 local_key） |
-| `client_type` | `uint8_t` | 客户端类型：`TAI_CLIENT_DEVICE` 或 `TAI_CLIENT_APP` |
-| `protocol_version` | `uint8_t` | 协议版本：使用 `TAI_VER_21` |
+| `client_type` | `uint8_t` | 客户端类型：`TAI_CLIENT_DEVICE` 或 `TAI_CLIENT_APP`（0 = 默认 `TAI_CLIENT_DEVICE`） |
+| `protocol_version` | `uint8_t` | 协议版本：使用 `TAI_VER_21`（0 = 默认 `TAI_VER_21`） |
 
 ### 3.3 会话选项
 
@@ -163,14 +164,14 @@ sidebar_position: 1
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `biz_code` | `uint32_t` | 业务码 |
-| `biz_tag` | `uint64_t` | 业务标签 |
+| `biz_code` | `uint32_t` | 业务码（0 = 默认 `65537`） |
+| `biz_tag` | `uint64_t` | 业务标签（0 = 默认 `119`） |
 
 ### 3.5 安全配置
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `sign_level` | `uint8_t` | 签名级别：`TAI_SIGN_NONE` / `TAI_SIGN_HMAC_SHA256`（推荐） |
+| `sign_level` | `uint8_t` | 签名级别：`TAI_SIGN_HMAC_SHA256`（推荐）或 `TAI_SIGN_HMAC_SHA1`。注意 `TAI_SIGN_NONE`（0）会被视为"未设置"而强制回退到 `TAI_SIGN_HMAC_SHA256`，无法通过该字段关闭签名 |
 
 ### 3.6 保活配置
 
@@ -178,7 +179,7 @@ sidebar_position: 1
 |------|------|------|
 | `ping_interval_ms` | `uint32_t` | Ping 间隔（0 = 默认 60000ms） |
 | `ping_timeout_ms` | `uint32_t` | Ping 超时（0 = 默认 90000ms） |
-| `connect_timeout_ms` | `uint32_t` | 连接超时（0 = 默认 5000ms）。分别约束 `tai_connect` 的两个串行等待阶段：先是 TLS 握手，再是服务端 SessionNew 应答。任一阶段超时即判定连接失败，因此 `tai_connect` 最坏耗时约为该值的 2 倍（握手 + 应答）。 |
+| `connect_timeout_ms` | `uint32_t` | 连接超时（0 = 默认 5000ms）。分别约束 `tai_connect` 的两个串行等待阶段：先是连接建立（TCP 建连 + TLS 握手，共用一份预算），再是服务端 SessionNew 应答。任一阶段超时即判定连接失败，因此 `tai_connect` 最坏耗时约为该值的 2 倍。 |
 
 ### 3.7 测试配置
 
@@ -191,6 +192,7 @@ sidebar_position: 1
 | 字段 | 类型 | 说明 |
 |------|------|------|
 | `pal` | `const pal_t *` | 平台适配层实现指针 |
+| `cert_bundle_attach` | `tls_cert_bundle_attach_fn` | 平台证书包回调（ESP-IDF 上设为 `esp_crt_bundle_attach`，否则 TLS 不做证书校验）；NULL 表示不使用。详见 [TLS 证书验证](../guides/tls-cert-verification.md) |
 
 ### 3.9 回调函数
 
@@ -410,7 +412,7 @@ void tai_request_disconnect(tai_ctx_t *ctx);
 int tai_send_text(tai_ctx_t *ctx, const char *text, size_t len);
 ```
 
-发送文本消息。单包完成（内部设置 `ONE_SHOT` 标志）。
+发送文本消息。一次调用内部依次发出 4 个应用包：`EventStart` → 文本（`ONE_SHOT` 标志）→ `EventPayloadsEnd` → `EventEnd`，调用方无需再手动收尾。
 
 **参数：**
 - `text` — UTF-8 文本
@@ -531,10 +533,10 @@ static inline int  tai_get_log_level(void);
 | 0 | 禁用所有日志 |
 | 1 | `TAI_LOG_ERROR` |
 | 2 | `TAI_LOG_WARN` |
-| 3 | `TAI_LOG_INFO` |
-| 4 | `TAI_LOG_DEBUG`（默认） |
+| 3 | `TAI_LOG_INFO`（运行时默认） |
+| 4 | `TAI_LOG_DEBUG` |
 
-编译时可通过定义 `TAI_LOG_LEVEL` 宏设置最大编译级别（超过的日志在编译期消除）。
+运行时默认级别为 `TAI_LOG_INFO`（3），需要 DEBUG 输出时显式调用 `tai_set_log_level(4)`。编译时可通过定义 `TAI_LOG_LEVEL` 宏设置最大编译级别（默认 4，超过的日志在编译期消除）。
 
 ---
 

--- a/docs-site/docs/tutorials/pair-by-ble.md
+++ b/docs-site/docs/tutorials/pair-by-ble.md
@@ -68,7 +68,7 @@ void app_main(void)
     nvs_flash_init();
 
     tuya_ble_prov_cfg_t prov_cfg = {
-        .device_name = "TuyaDevice",    // BLE 广播名称
+        .device_name = "TYBLE",         // BLE 广播名称（最长 5 字符，超出会被截断）
         .product_key = PRODUCT_KEY,     // 产品 PID
         .uuid        = DEVICE_UUID,     // 设备 UUID
         .auth_key    = AUTH_KEY,        // 设备 Auth Key
@@ -91,7 +91,7 @@ void app_main(void)
 ### 配置文件 `app_config.h`
 
 ```c
-#define TUYA_BLE_DEVICE_NAME  "TuyaDevice"
+#define TUYA_BLE_DEVICE_NAME  "TYBLE"   // 最长 5 字符（TUYA_BLE_NAME_MAX_LEN），超出会被截断
 #define PRODUCT_KEY           "your_product_key"
 #define DEVICE_UUID           "your_uuid"
 #define AUTH_KEY              "your_auth_key"
@@ -115,7 +115,7 @@ int tuya_ble_nimble_start(const tuya_ble_prov_cfg_t *cfg);
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `device_name` | `const char *` | BLE 广播设备名 |
+| `device_name` | `const char *` | BLE 广播设备名（最长 5 字符 `TUYA_BLE_NAME_MAX_LEN`，超出部分被静默截断） |
 | `product_key` | `const char *` | 产品 PID |
 | `uuid` | `const char *` | 设备 UUID |
 | `auth_key` | `const char *` | 设备 Auth Key |

--- a/docs-site/docs/tutorials/quick-start.md
+++ b/docs-site/docs/tutorials/quick-start.md
@@ -22,6 +22,7 @@ sidebar_position: 1
 | 工具/库 | 版本 | macOS 安装 | Linux (Debian/Ubuntu) 安装 |
 |---------|------|-----------|---------------------------|
 | CMake | ≥ 3.20 | `brew install cmake` | `apt install cmake` |
+| Python3 | ≥ 3.x | `brew install python3` | `apt install python3` |
 
 > 构建系统会自动编译 bundled 的 mbedTLS、cJSON、coreHTTP、coreMQTT 依赖，无需单独安装。
 
@@ -39,15 +40,15 @@ mkdir -p build && cd build
 cmake .. && make
 ```
 
-CMakeLists.txt 会自动选择平台对应的预编译库目录：
+CMakeLists.txt 会自动选择平台对应的预编译库目录（位于 `modules/rtc-client/libs/`）：
 
 | 平台 | 库目录 |
 |------|--------|
-| macOS arm64 | `libs/macos_arm64/` |
-| Linux x86_64 | `libs/linux-gnu-amd64/` |
-| Linux aarch64 | `libs/linux-gnu-aarch64/` |
+| macOS arm64 | `modules/rtc-client/libs/macos_arm64/` |
+| Linux x86_64 | `modules/rtc-client/libs/linux-gnu-amd64/` |
+| Linux aarch64 | `modules/rtc-client/libs/linux-gnu-aarch64/` |
 
-其他可用预编译库（需手动指定）：`libs/rockchip830-arm/`、`libs/ingenic-mips/`。
+其他可用预编译库：`modules/rtc-client/libs/rockchip830-arm/`、`modules/rtc-client/libs/ingenic-mips/`。交叉编译这两个平台时，库目录的选择逻辑硬编码在根 `CMakeLists.txt` 的平台判断中（`STEAM_CLIENT_LIB_DIR`），需自行修改该处指向对应目录。
 
 
 ### 示例代码编译

--- a/docs-site/docs/tutorials/scan-by-device.md
+++ b/docs-site/docs/tutorials/scan-by-device.md
@@ -123,22 +123,22 @@ iot_client_t *iot_client_init_on_boarding_with_token(
 成功输出示例：
 
 ```
-=== pair example ===
+=== scan-by-device pair demo ===
 QR image     : res/qr.jpg
 UUID         : tuyaXXXXXXXXXXXX
 Product key  : p891xbkosae0dgda
 
-[pair] Image loaded: qr.jpg (400x400)
-[pair] QR payload: {"s":"MyWiFi","p":"password123","t":"AY..."}
-[pair] SSID    : MyWiFi
-[pair] Password: password123
-[pair] Token   : AY...
-[pair] Starting on-boarding with token...
-[pair] Activation successful!
-[pair] devid      : <device_id>
-[pair] secret_key : <secret_key>
-[pair] local_key  : <local_key>
-[pair] Session token acquired (len=1234)
+[scan_by_device] Image loaded: res/qr.jpg (400x400)
+[scan_by_device] QR payload: {"s":"MyWiFi","p":"password123","t":"AY..."}
+[scan_by_device] SSID    : MyWiFi
+[scan_by_device] Password: password123
+[scan_by_device] Token   : AY...
+[scan_by_device] Starting on-boarding with token...
+[scan_by_device] Activation successful!
+[scan_by_device] devid      : <device_id>
+[scan_by_device] secret_key : <secret_key>
+[scan_by_device] local_key  : <local_key>
+[scan_by_device] Session token acquired (len=1234)
 ```
 
 激活成功后，请将输出的 `devid`、`secret_key`、`local_key` 保存到设备持久化

--- a/modules/rtc-tcp-client/CONTEXT.md
+++ b/modules/rtc-tcp-client/CONTEXT.md
@@ -75,7 +75,7 @@ The liveness exchange the background thread runs: it sends a Ping every `ping_in
 (default 60 s) and treats the Connection as dead if no inbound traffic — a Pong *or any*
 received data — arrives within `ping_timeout_ms` (default 90 s), then fires `on_disconnect`.
 Counting any receive, not just Pong, keeps a long downstream stream from tripping a spurious
-timeout (see [ADR 0001](docs/adr/0001-receive-worker-callback-greedy-nest.md)).
+timeout.
 _Avoid_: heartbeat, poll.
 
 **Chat break**:
@@ -125,7 +125,7 @@ with another sender (including the worker's Ping). The receive buffers are touch
 the worker, so receiving — and the user callbacks dispatched from it — is lock-free; mbedTLS
 read and write are serialised inside the TLS layer, so the worker can read while a caller
 writes. (The shared PAL mutex is *recursive*, but TAI does not rely on that — the recursion
-exists for the IoT DP layer; see [ADR 0001](docs/adr/0001-receive-worker-callback-greedy-nest.md).)
+exists for the IoT DP layer; see the `mutex_create` contract in `pal/pal.h`.)
 
 ### Sending
 
@@ -234,8 +234,7 @@ freed memory. Because it joins the worker, it must run on a thread *other* than 
 (no join), so it is safe from any thread including a receive callback; the owning thread must
 still call `tai_disconnect` afterwards to join and release. Receive callbacks therefore have a
 re-entrancy contract — may call `tai_send_*`, must not call `tai_disconnect` / `tai_ctx_deinit`,
-must not block — captured in [ADR 0001](docs/adr/0001-receive-worker-callback-greedy-nest.md)
-and `tuya_ai.h`.
+must not block — captured in the callback-contract block in `tuya_ai.h`.
 
 ### Invariants
 

--- a/modules/rtc-tcp-client/include/tuya_ai.h
+++ b/modules/rtc-tcp-client/include/tuya_ai.h
@@ -383,7 +383,7 @@ int tai_send_mcp_response(tai_ctx_t *ctx, const char *json_rpc_response);
  *
  *   1. Compile-time maximum (TAI_LOG_LEVEL, default 4 = DEBUG).
  *      Messages above this level are optimised away at build time.
- *   2. Runtime level, set via tai_set_log_level().  Default: TAI_LOG_DEBUG.
+ *   2. Runtime level, set via tai_set_log_level().  Default: TAI_LOG_INFO.
  *
  * These thin inlines exist for source-compatibility with callers; new
  * code should prefer log_set_level() / log_get_level() directly.


### PR DESCRIPTION
## Summary

Documentation-accuracy pass: every claim in the READMEs and all docs-site pages was verified against the current code, fixing ~20 inaccuracies. Docs-only — the single source change is a stale log-level comment in `tuya_ai.h`.

The two functional changes originally on this branch were split out into their own PRs: the SG-region ATOP host fix (`fix/iot-client-sg-atop-host`) and the caller-provided-buffers refactor (`refactor/iot-client-caller-provided-buffers`).

## Changes

**READMEs**
- The Tuya BLE public header is `tuya_ble_prov.h` — `tuya_ble_nimble.h` is example glue.
- Example builds now use a separate `build-examples/` directory so they no longer clash with the SDK `build/` cache (the top-level build has examples OFF by default).
- The Chinese license summary restores the modify/merge/publish rights the LICENSE actually grants.

**rtc-tcp-client reference**
- Runtime log default is INFO, not DEBUG (the stale header comment in `tuya_ai.h` is fixed too).
- `TAI_SIGN_NONE` (0) is treated as unset and cannot disable signing.
- Added the missing `cert_bundle_attach` field and `TAI_PKT_AUTHENTICATE_RESPONSE`; `tai_send_text` emits 4 packets.
- Documented zero-value config defaults and the TCP-connect share of `connect_timeout_ms`.

**rtc-client reference**
- Added missing `stm_open_data_t` / `stm_audio_params_t` fields; dropped the unsupported "MCP via CMD type" claim.

**Concepts / architecture**
- Reconnection is app-driven for rtc-tcp-client (matches the FAQ and the header contract).
- PAL is 14 interfaces; iot-client ships `src/`, not `libs/`.

**Tutorials & guides**
- quick-start: added the required Python3 dependency; corrected precompiled-lib paths to `modules/rtc-client/libs/`; `STEAM_CLIENT_LIB_DIR` is hardcoded.
- porting guide: dropped a drifting `pal.h` line reference; the `tai_ctx_size()` default is ~38 KB, not "hundreds of KB".
- scan-by-device: refreshed the sample output to the current demo banner/prefix.
- pair-by-ble: the advertised name is truncated to 5 characters — use "TYBLE".

**Cross-references**
- CONTEXT-MAP / rtc-tcp-client CONTEXT: repointed dangling references to the removed `docs/adr/0001` at the surviving content in `tuya_ai.h` / `pal.h`.
