### PR TITLE
fix(iot-client): map SG region to its own ATOP host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- iot-client — SG region no longer falls back to the China ATOP host(#9).
+  - `iot_region_to_host()` was missing a `case SG:`, so token-based
+    activation and every ATOP fallback path (session token, DP schema
+    update, OTA, version report when IoT-DNS is unavailable) for Singapore
+    devices went to `a1.tuyacn.com` instead of `a1-sg.iotbing.com`. The
+    `IOT_SG_HOST` macro existed but was never referenced. MQTT is
+    unaffected — its URL comes exclusively from IoT-DNS.
+
 - iot-client — US region renamed to AZ(#7).
   - The IoT DNS region string and token prefix for the US West (Oregon) data
     center is `AZ`, not `US`. The enum member `US` is renamed to `AZ`,

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -148,7 +148,7 @@ struct iot_dp_context;
     char mqtt_url[64];            // MQTT broker URL (inline, mqtt://|mqtts://; "" = unresolved)
     char *schema;                 // Device schema JSON (dynamically allocated)
 
-    iot_region_t region;           // Server region (CN, AZ, EU, IN)
+    iot_region_t region;           // Server region (AY/AZ/UEAZ/EU/WEAZ/IN/SG)
     iot_env_t env;                 // Environment (PROD or PRE)
     bool mqtt_disable_tls;         // false = mqtts (TLS), true = mqtt (TCP)
     const pal_t *pal;             // PAL adapter

--- a/modules/iot-client/src/iot_dns.c
+++ b/modules/iot-client/src/iot_dns.c
@@ -379,6 +379,8 @@ char *iot_region_to_host(iot_region_t region, iot_env_t env)
                     return IOT_WEAZ_HOST;
                 case IN:
                     return IOT_IN_HOST;
+                case SG:
+                    return IOT_SG_HOST;
                 default:
                     return IOT_DEFAULT_HOST;
                 }

--- a/modules/iot-client/test/dns_test.c
+++ b/modules/iot-client/test/dns_test.c
@@ -103,6 +103,35 @@ static void stop_mock(void)
     }
 }
 
+/* ========== Static region -> host mapping ========== */
+
+/* Every enum region must map to its own PROD ATOP host — a region falling
+ * through to the China default silently sends ATOP traffic to the wrong data
+ * center (regression: SG was missing and hit a1.tuyacn.com). */
+static int test_region_to_host_prod_mapping(void)
+{
+    static const struct { iot_region_t region; const char *host; } cases[] = {
+        { AY,   IOT_CN_HOST },
+        { AZ,   IOT_AZ_HOST },
+        { UEAZ, IOT_UEAZ_HOST },
+        { EU,   IOT_EU_HOST },
+        { WEAZ, IOT_WEAZ_HOST },
+        { IN,   IOT_IN_HOST },
+        { SG,   IOT_SG_HOST },
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        const char *host = iot_region_to_host(cases[i].region, PROD);
+        if (!host || strcmp(host, cases[i].host) != 0) {
+            printf("  region %d: expected %s, got %s\n",
+                   (int)cases[i].region, cases[i].host, host ? host : "(null)");
+            return -1;
+        }
+    }
+    printf("  all %zu regions map to their own PROD host\n",
+           sizeof(cases) / sizeof(cases[0]));
+    return OPRT_OK;
+}
+
 /* ========== Parameter validation tests ========== */
 
 static int test_dns_query_null_params(void)
@@ -662,6 +691,9 @@ int main(void)
         return 1;
     }
     sleep(1);
+
+    /* Static region -> host mapping */
+    RUN_TEST(test_region_to_host_prod_mapping);
 
     /* Parameter validation */
     RUN_TEST(test_dns_query_null_params);


### PR DESCRIPTION
iot_region_to_host() had no case SG:, so Singapore devices fell through to the China default — token-based activation and every ATOP fallback path (session token, DP schema update, OTA, version report when IoT-DNS is unavailable) went to a1.tuyacn.com instead of a1-sg.iotbing.com. The IOT_SG_HOST macro existed but was never referenced.

MQTT is unaffected: its URL comes exclusively from the IoT-DNS query, which already passes the correct "SG" region string.

Add a regression test asserting all seven regions map to their own PROD host, so a future region addition cannot silently fall back to China again. Also refresh the stale region list comment in iot_client.h, and categorize the Unreleased changelog entries under a Fixed heading to match the 0.3.0 section style.