### PR TITLE
refactor(iot-client)!: caller-provided buffers for qrcode URL and CA …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- iot-client — SG region no longer falls back to the China ATOP host(#9).
-  - `iot_region_to_host()` was missing a `case SG:`, so token-based
-    activation and every ATOP fallback path (session token, DP schema
-    update, OTA, version report when IoT-DNS is unavailable) for Singapore
-    devices went to `a1.tuyacn.com` instead of `a1-sg.iotbing.com`. The
-    `IOT_SG_HOST` macro existed but was never referenced. MQTT is
-    unaffected — its URL comes exclusively from IoT-DNS.
+- iot-client — `iot_get_qrcode_info` and `iot_get_ca_certificate` now write
+  into caller-provided buffers (API break)(#10).
+  - The single-field `iot_qrcode_response_t` struct is removed and both APIs
+    take `char *buf, size_t buf_len` instead of returning pal-allocated
+    strings — no heap ownership passes to the caller, matching the
+    `iot_client_get_session_token` convention. Both return
+    `OPRT_INVALID_RESULT` if the buffer is too small.
+  - `iot_get_ca_certificate` now also returns `OPRT_INVALID_RESULT` when the
+    server has no CA certificate for the endpoint (previously an empty string
+    was silently returned as success).
+
+### Fixed
 
 - iot-client — US region renamed to AZ(#7).
   - The IoT DNS region string and token prefix for the US West (Oregon) data

--- a/docs-site/docs/guides/tls-cert-verification.md
+++ b/docs-site/docs/guides/tls-cert-verification.md
@@ -72,23 +72,22 @@ iot_client_t *client = iot_client_init(&cfg);
 
 ```c
 int iot_get_ca_certificate(iot_client_t *client, const char *host,
-                           uint16_t port, char **ca_certificate);
+                           uint16_t port, char *ca_certificate, size_t ca_certificate_len);
 ```
 
 ```c
-/* 查询目标端点（例如 ATOP/HTTPS 主机用 443，MQTT 用 8883）的 CA 证书。 */
-char *ca_cert = NULL;
-int rc = iot_get_ca_certificate(client, "a1.tuyacn.com", 443, &ca_cert);
-if (rc == OPRT_OK && ca_cert != NULL) {
-    /* ... 使用 / 持久化 ca_cert ... */
-
-    /* ca_cert 由 PAL 分配（pal_strdup），必须用同一个 PAL 的 free 释放，
-       不能用 libc free()；且需在 iot_client_deinit() 之前（client->pal 仍有效时）释放。 */
-    client->pal->free(ca_cert);
+/* 查询目标端点（例如 ATOP/HTTPS 主机用 443，MQTT 用 8883）的 CA 证书。
+   证书写入调用方提供的缓冲区——单个 CA PEM 通常 1-2KB，4096 字节足够；
+   缓冲区不够大时返回 OPRT_INVALID_RESULT。 */
+static char ca_cert[4096];
+int rc = iot_get_ca_certificate(client, "a1.tuyacn.com", 443, ca_cert, sizeof(ca_cert));
+if (rc == OPRT_OK) {
+    /* ... 使用 / 持久化 ca_cert ...
+       若赋给 client->cacert 长期使用，缓冲区生命周期须覆盖 client（如 static）。 */
 }
 ```
 
-> **引导阶段的“先有鸡还是先有蛋”问题：** `iot_get_ca_certificate()` 本身要先建立一次到 IoT-DNS 的 TLS 连接；若此时 `client->cacert` 仍为空，这次查询以不校验方式进行——存在引导阶段 MITM 风险。同理，`iot_client_init()` 在返回前就已完成 DNS/ATOP/MQTT 的**首批连接**，因此**在 init 之后再设 `client->cacert` 只对后续请求生效，无法追溯保护 init 期间的连接**。
+> **引导阶段的“先有鸡还是先有蛋”问题：** `iot_get_ca_certificate()` 本身要先建立一次到 IoT-DNS 的 TLS 连接；若此时 `client->cacert` 仍为空，这次查询以不校验方式进行——存在引导阶段 MITM 风险。同理，`iot_client_init()` 在返回前就已完成 DNS/ATOP 的**首批连接**（若 `mqtt_auto_connect = true`——默认为 false——还包括 MQTT 首连），因此**在 init 之后再设 `client->cacert` 只对后续请求生效，无法追溯保护 init 期间的连接**。
 >
 > 所以运行时获取 CA 更适合用来**取回一份 CA 加以持久化**，下次启动前通过 `cfg.cacert` 在 `iot_client_init()` **之前**传入，从第一条连接起即校验；对安全要求严格的场景，建议直接硬编码根 CA 或改用 `.cert_bundle_attach`。
 

--- a/docs-site/docs/reference/iot-client.md
+++ b/docs-site/docs/reference/iot-client.md
@@ -6,7 +6,11 @@ sidebar_position: 3
 
 # IoT Client API 参考文档
 
-`libiot_sdk` 提供设备激活、MQTT 连接和会话令牌获取功能。头文件：`modules/iot-client/include/iot_client.h`。
+IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.a`）提供设备激活、MQTT 连接和会话令牌获取功能。头文件：`modules/iot-client/include/iot_client.h`。
+
+:::caution 前置调用
+使用任何 SDK 函数前，必须先调用 [`iot_init()` 或 `iot_init_default()`](#iot_init--iot_init_default) 初始化 PAL。未初始化时 `iot_client_init()` 直接返回 `NULL`，`iot_get_qrcode_info()` 返回 `OPRT_UNINITIALIZED`。
+:::
 
 ## 激活请求补充说明
 
@@ -66,6 +70,8 @@ sidebar_position: 3
 ### Log Level（`log_level_t`）
 
 日志通过 `common/log.h` 的全局日志门面控制，使用 `log_set_level()` 设置运行时级别，使用 `log_set_handler()` 自定义输出。
+
+注：`log_level_t` 并非枚举，而是 `typedef int`（以便 `LOG_*` 可用于预处理器 `#if` 判断），下表中的名称均为宏定义。
 
 | 值 | 名称 |
 |----|------|
@@ -133,6 +139,19 @@ sidebar_position: 3
 | `env` | `iot_env_t` | 环境 |
 
 ## API 函数
+
+### `iot_init` / `iot_init_default`
+
+```c
+int iot_init(const pal_t *pal);
+int iot_init_default(void);
+```
+
+初始化 IoT SDK 的平台抽象层（PAL），**必须先于任何其他 SDK 函数调用**。`iot_init_default()` 使用内置的默认 PAL 适配器（POSIX / FreeRTOS）；`iot_init()` 使用自定义 PAL（详见[适配新平台](../guides/porting-to-new-platform.md)）。
+
+**返回值：** `OPRT_OK` 成功；`iot_init()` 在 `pal` 为 NULL 或必需函数指针缺失时返回 `OPRT_INVALID_PARAMETER`。
+
+---
 
 ### `iot_client_init`
 
@@ -240,8 +259,7 @@ int iot_client_publish(iot_client_t *client, const uint8_t *data, size_t data_le
 ### `iot_get_qrcode_info`
 
 ```c
-int iot_get_qrcode_info(const iot_qrcode_request_t *request,
-                        iot_qrcode_response_t *response);
+int iot_get_qrcode_info(const iot_qrcode_request_t *request, char *url, size_t url_len);
 ```
 
 从涂鸦云获取配网激活 URL，设备可将此 URL 编码为二维码展示给用户。
@@ -259,21 +277,19 @@ int iot_get_qrcode_info(const iot_qrcode_request_t *request,
 | `cacert` | `const char *` | CA 证书 PEM（用于 HTTPS/IoT-DNS TLS，调用方持有） |
 | `cert_bundle_attach` | `tls_cert_bundle_attach_fn` | 平台证书包回调（如 ESP-IDF 的 `esp_crt_bundle_attach`），NULL 表示不使用。详见 [TLS 证书验证](../guides/tls-cert-verification.md) |
 
-**响应 `iot_qrcode_response_t`：**
+**出参：**
+- `url` — 调用方分配的缓冲区，接收以 NUL 结尾的激活 URL
+- `url_len` — 缓冲区大小（字节）
 
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `url` | `char *` | 激活 URL（调用方需 `free`） |
-
-**返回值：** `OPRT_OK` 成功。
+**返回值：** `OPRT_OK` 成功；`request`/`url` 为 NULL 或 `url_len` 为 0 时返回 `OPRT_INVALID_PARAMETER`；缓冲区不够大时返回 `OPRT_INVALID_RESULT`。
 
 ---
 
 ### `iot_get_ca_certificate`
 
 ```c
-int iot_get_ca_certificate(iot_client_t *client, const char *host,
-                           uint16_t port, char **ca_certificate);
+int iot_get_ca_certificate(iot_client_t *client, const char *host, uint16_t port,
+                           char *ca_certificate, size_t ca_certificate_len);
 ```
 
 获取目标主机的 CA 证书。
@@ -282,9 +298,10 @@ int iot_get_ca_certificate(iot_client_t *client, const char *host,
 - `client` — IoT 客户端实例（不可为 NULL）
 - `host` — 目标主机名
 - `port` — 目标端口
-- `ca_certificate` — 输出 CA 证书字符串（调用方需 `free`）
+- `ca_certificate` — 调用方分配的缓冲区，接收以 NUL 结尾的 CA 证书 PEM 字符串（单个 CA PEM 通常 1-2KB，建议 4096 字节）
+- `ca_certificate_len` — 缓冲区大小（字节）
 
-**返回值：** `OPRT_OK` 成功；`client` 或 `host` 为 NULL 时返回 `OPRT_INVALID_PARAMETER`。
+**返回值：** `OPRT_OK` 成功；`client`/`host`/`ca_certificate` 为 NULL 或 `ca_certificate_len` 为 0 时返回 `OPRT_INVALID_PARAMETER`；无可用证书或缓冲区不够大时返回 `OPRT_INVALID_RESULT`。
 
 ---
 

--- a/docs-site/docs/tutorials/scan-by-app.md
+++ b/docs-site/docs/tutorials/scan-by-app.md
@@ -49,8 +49,7 @@ iot_client_deinit()                  // 5. 清理资源
 ### `iot_get_qrcode_info()`
 
 ```c
-int iot_get_qrcode_info(const iot_qrcode_request_t *request,
-                        iot_qrcode_response_t *response);
+int iot_get_qrcode_info(const iot_qrcode_request_t *request, char *url, size_t url_len);
 ```
 
 向涂鸦云请求一个用于配网激活的 URL。设备将此 URL 编码为二维码展示给用户。
@@ -63,9 +62,11 @@ int iot_get_qrcode_info(const iot_qrcode_request_t *request,
 | `authkey` | 设备 Auth Key |
 | `app_id` | App ID（可为空字符串） |
 | `type` | 二维码类型（通常为 1） |
+| `region` | 数据中心区域（默认 `AY` 中国） |
 | `env` | 环境：`PROD` / `PRE` |
+| `cacert` / `cert_bundle_attach` | HTTPS/IoT-DNS 的 TLS 证书配置，详见 [TLS 证书验证](../guides/tls-cert-verification.md) |
 
-**返回值：** `OPRT_OK` 表示成功，`response->url` 中包含激活 URL（调用方需 `free`）。
+**返回值：** `OPRT_OK` 表示成功，激活 URL 写入调用方提供的 `url` 缓冲区（NUL 结尾；缓冲区不够大时返回 `OPRT_INVALID_RESULT`）。
 
 ### `iot_client_init_on_boarding()`
 

--- a/examples/esp-idf/pair/scan-by-app/main/scan_by_app_pair_demo.c
+++ b/examples/esp-idf/pair/scan-by-app/main/scan_by_app_pair_demo.c
@@ -81,22 +81,22 @@ int demo_scan_by_app_pair_run(const char *uuid, const char *authkey,
         .type    = 1,
         .env     = ob_config.env,
     };
-    iot_qrcode_response_t qr_resp = {0};
+    char qr_url[256] = {0};
 
-    int qr_ret = iot_get_qrcode_info(&qr_req, &qr_resp);
-    if (qr_ret != OPRT_OK || !qr_resp.url) {
+    int qr_ret = iot_get_qrcode_info(&qr_req, qr_url, sizeof(qr_url));
+    if (qr_ret != OPRT_OK) {
         fprintf(stderr, "[%s] iot_get_qrcode_info failed (%d)\n", TAG, qr_ret);
         return -1;
     }
 
-    printf("=== QR Code URL ===\n  %s\n\n", qr_resp.url);
+    printf("=== QR Code URL ===\n  %s\n\n", qr_url);
 
     /* -- Step 2: Render QR code in terminal -------------------------------- */
     uint8_t qr_buf[qrcodegen_BUFFER_LEN_MAX];
     uint8_t tmp_buf[qrcodegen_BUFFER_LEN_MAX];
 
     bool ok = qrcodegen_encodeText(
-        qr_resp.url, tmp_buf, qr_buf,
+        qr_url, tmp_buf, qr_buf,
         qrcodegen_Ecc_LOW, qrcodegen_VERSION_MIN, qrcodegen_VERSION_MAX,
         qrcodegen_Mask_AUTO, true);
 
@@ -107,8 +107,6 @@ int demo_scan_by_app_pair_run(const char *uuid, const char *authkey,
     } else {
         printf("(QR code too long to render in terminal; use the URL above)\n\n");
     }
-
-    free(qr_resp.url);
 
     /* -- Step 3: On-boarding ----------------------------------------------- */
     iot_client_t *client = NULL;

--- a/examples/posix/dp-management/dp_management_demo.c
+++ b/examples/posix/dp-management/dp_management_demo.c
@@ -167,27 +167,27 @@ static void on_schema_update(const char *schema_id, const char *new_schema, void
 
 /* Resolve and attach the MQTT broker's CA (when using TLS and none was supplied),
  * so the demo connects against the real cloud without bundling a cert file.
- * Returns the allocated cert (assign to client->cacert; free at shutdown) or NULL. */
-static char *ensure_mqtt_ca(iot_client_t *client)
+ * The cert lives in a static buffer that outlives the client. */
+static void ensure_mqtt_ca(iot_client_t *client)
 {
+    static char mqtt_ca[4096];
+
     if (client->mqtt_disable_tls || client->cacert || client->mqtt_url[0] == '\0')
-        return NULL;
+        return;
 
     char scheme[8] = {0};
     char host[128] = {0};
     unsigned port = 0;
     if (sscanf(client->mqtt_url, "%7[^:]://%127[^:]:%u", scheme, host, &port) != 3) {
         fprintf(stderr, "[%s] cannot parse mqtt_url: %s\n", TAG, client->mqtt_url);
-        return NULL;
+        return;
     }
 
-    char *ca = NULL;
-    if (iot_get_ca_certificate(client, host, (uint16_t)port, &ca) != OPRT_OK || !ca) {
+    if (iot_get_ca_certificate(client, host, (uint16_t)port, mqtt_ca, sizeof(mqtt_ca)) != OPRT_OK) {
         fprintf(stderr, "[%s] failed to fetch MQTT CA for %s:%u\n", TAG, host, port);
-        return NULL;
+        return;
     }
-    client->cacert = ca;   /* must outlive the client */
-    return ca;
+    client->cacert = mqtt_ca;
 }
 
 /* Connect and immediately re-publish full state — the cloud only learns DP state
@@ -334,9 +334,8 @@ int demo_dp_management_run(const char *devid,
     iot_dp_set_schema_update_callback(client, on_schema_update, NULL);
 
     /* 4. CA + connect + report-on-connect. */
-    char *mqtt_ca = ensure_mqtt_ca(client);
+    ensure_mqtt_ca(client);
     if (connect_and_report(client) != OPRT_OK) {
-        if (mqtt_ca) client->pal->free(mqtt_ca);
         iot_client_deinit(client);
         return -1;
     }
@@ -387,7 +386,6 @@ int demo_dp_management_run(const char *devid,
 
     /* 7. Tear down. */
     iot_client_message_disconnect(client);
-    if (mqtt_ca) client->pal->free(mqtt_ca);
     iot_client_deinit(client);
     return 0;
 }

--- a/examples/posix/pair/scan-by-app/scan_by_app_pair_demo.c
+++ b/examples/posix/pair/scan-by-app/scan_by_app_pair_demo.c
@@ -81,22 +81,22 @@ int demo_scan_by_app_pair_run(const char *uuid, const char *authkey,
         .type    = 1,
         .env     = ob_config.env,
     };
-    iot_qrcode_response_t qr_resp = {0};
+    char qr_url[256] = {0};
 
-    int qr_ret = iot_get_qrcode_info(&qr_req, &qr_resp);
-    if (qr_ret != OPRT_OK || !qr_resp.url) {
+    int qr_ret = iot_get_qrcode_info(&qr_req, qr_url, sizeof(qr_url));
+    if (qr_ret != OPRT_OK) {
         fprintf(stderr, "[%s] iot_get_qrcode_info failed (%d)\n", TAG, qr_ret);
         return -1;
     }
 
-    printf("=== QR Code URL ===\n  %s\n\n", qr_resp.url);
+    printf("=== QR Code URL ===\n  %s\n\n", qr_url);
 
     /* -- Step 2: Render QR code in terminal -------------------------------- */
     uint8_t qr_buf[qrcodegen_BUFFER_LEN_MAX];
     uint8_t tmp_buf[qrcodegen_BUFFER_LEN_MAX];
 
     bool ok = qrcodegen_encodeText(
-        qr_resp.url, tmp_buf, qr_buf,
+        qr_url, tmp_buf, qr_buf,
         qrcodegen_Ecc_LOW, qrcodegen_VERSION_MIN, qrcodegen_VERSION_MAX,
         qrcodegen_Mask_AUTO, true);
 
@@ -107,8 +107,6 @@ int demo_scan_by_app_pair_run(const char *uuid, const char *authkey,
     } else {
         printf("(QR code too long to render in terminal; use the URL above)\n\n");
     }
-
-    free(qr_resp.url);
 
     /* -- Step 3: On-boarding ----------------------------------------------- */
     iot_client_t *client = NULL;

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -248,13 +248,18 @@ IOT_API int iot_client_get_session_token(iot_client_t *client, const char *agent
 /**
  * @brief Get CA certificate for a target host via IoT DNS service.
  *
- * @param client         Pointer to iot_client_t instance (must not be NULL)
- * @param host           Target host to get certificate for
- * @param port           Target port
- * @param ca_certificate Output CA certificate PEM string (caller must free via pal->free)
- * @return OPRT_OK on success, OPRT_INVALID_PARAMETER if client or host is NULL
+ * @param client             Pointer to iot_client_t instance (must not be NULL)
+ * @param host               Target host to get certificate for
+ * @param port               Target port
+ * @param ca_certificate     Caller-provided buffer receiving the NUL-terminated
+ *                           CA certificate PEM string (a single CA PEM is
+ *                           typically 1-2 KB; 4096 bytes is a safe size)
+ * @param ca_certificate_len Size of the ca_certificate buffer in bytes
+ * @return OPRT_OK on success, OPRT_INVALID_PARAMETER if client/host/ca_certificate
+ *         is NULL or ca_certificate_len is 0, OPRT_INVALID_RESULT if no CA cert
+ *         is available or the buffer is too small
  */
-IOT_API int iot_get_ca_certificate(iot_client_t *client, const char *host, uint16_t port, char **ca_certificate);
+IOT_API int iot_get_ca_certificate(iot_client_t *client, const char *host, uint16_t port, char *ca_certificate, size_t ca_certificate_len);
 
 /**
  * @brief QR code info request parameters
@@ -271,22 +276,17 @@ typedef struct {
 } iot_qrcode_request_t;
 
 /**
- * @brief QR code info response
- */
-typedef struct {
-    char *url;                // QR code URL (caller must free)
-} iot_qrcode_response_t;
-
-/**
- * @brief Get QR code info from Tuya cloud.
+ * @brief Get the QR code activation URL from Tuya cloud.
  *
  * Resolves the ATOP endpoint and CA certificate via IoT DNS automatically —
- * does not require an initialized client.  The caller must free response->url.
+ * does not require an initialized client.
  *
  * @param[in]  request  Request parameters (uuid, authkey, app_id, type, region, env)
- * @param[out] response Response containing QR code URL (caller must free url)
- * @return OPRT_OK on success, OPRT_INVALID_PARAMETER if request or response is NULL
+ * @param[out] url      Caller-provided buffer receiving the NUL-terminated URL
+ * @param[in]  url_len  Size of the url buffer in bytes
+ * @return OPRT_OK on success, OPRT_INVALID_PARAMETER if request or url is NULL
+ *         or url_len is 0, OPRT_INVALID_RESULT if the buffer is too small
  */
-IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, iot_qrcode_response_t *response);
+IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, char *url, size_t url_len);
 
 #endif /* _IOT_CLIENT_H_ */

--- a/modules/iot-client/src/iot_client.c
+++ b/modules/iot-client/src/iot_client.c
@@ -537,9 +537,9 @@ IOT_API int iot_client_publish(iot_client_t *client, const uint8_t *data, size_t
     return iot_client_message_publish(client, data, data_len);
 }
 
-IOT_API int iot_get_ca_certificate(iot_client_t *client, const char *host, uint16_t port, char **ca_certificate)
+IOT_API int iot_get_ca_certificate(iot_client_t *client, const char *host, uint16_t port, char *ca_certificate, size_t ca_certificate_len)
 {
-    if (client == NULL || host == NULL) {
+    if (client == NULL || host == NULL || ca_certificate == NULL || ca_certificate_len == 0) {
         return OPRT_INVALID_PARAMETER;
     }
 
@@ -560,18 +560,24 @@ IOT_API int iot_get_ca_certificate(iot_client_t *client, const char *host, uint1
         log_error("iot_dns_get_ca_cert failed: %d", ret);
         return ret;
     }
-    *ca_certificate = NULL;
-    if (resp.ca_certificate) {
-        *ca_certificate = pal_strdup(pal, resp.ca_certificate);
-    }
-    iot_dns_ca_cert_response_free(pal, &resp);
-    if (*ca_certificate == NULL) {
+    size_t cert_len = resp.ca_certificate ? strlen(resp.ca_certificate) : 0;
+    if (cert_len == 0) {
+        log_error("iot_get_ca_certificate: no CA cert for %s:%u", host, port);
+        iot_dns_ca_cert_response_free(pal, &resp);
         return OPRT_INVALID_RESULT;
     }
+    if (cert_len >= ca_certificate_len) {
+        log_error("ca_certificate buffer too small: need %zu, have %zu", cert_len + 1, ca_certificate_len);
+        iot_dns_ca_cert_response_free(pal, &resp);
+        return OPRT_INVALID_RESULT;
+    }
+    memcpy(ca_certificate, resp.ca_certificate, cert_len);
+    ca_certificate[cert_len] = '\0';
+    iot_dns_ca_cert_response_free(pal, &resp);
     return OPRT_OK;
 }
 
-IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, iot_qrcode_response_t *response)
+IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, char *url, size_t url_len)
 {
     const pal_t *pal = get_pal();
     if (!pal) {
@@ -579,7 +585,7 @@ IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, iot_qrcode_
         return OPRT_UNINITIALIZED;
     }
 
-    if (request == NULL || response == NULL) {
+    if (request == NULL || url == NULL || url_len == 0) {
         return OPRT_INVALID_PARAMETER;
     }
 
@@ -641,6 +647,14 @@ IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, iot_qrcode_
         return ret;
     }
 
-    response->url = resp.short_url;
+    size_t resp_url_len = strlen(resp.short_url);
+    if (resp_url_len >= url_len) {
+        log_error("url buffer too small: need %zu, have %zu", resp_url_len + 1, url_len);
+        pal->free(resp.short_url);
+        return OPRT_INVALID_RESULT;
+    }
+    memcpy(url, resp.short_url, resp_url_len);
+    url[resp_url_len] = '\0';
+    pal->free(resp.short_url);
     return OPRT_OK;
 }

--- a/modules/iot-client/test/atop_test.c
+++ b/modules/iot-client/test/atop_test.c
@@ -486,7 +486,7 @@ static int test_qrcode_info(void)
 
 static int test_qrcode_info_null_params(void)
 {
-    int rt = iot_get_qrcode_info(NULL, NULL);
+    int rt = iot_get_qrcode_info(NULL, NULL, 0);
     if (rt != OPRT_INVALID_PARAMETER) {
         printf("  expected OPRT_INVALID_PARAMETER, got %d\n", rt);
         return -1;


### PR DESCRIPTION
…cert

iot_get_qrcode_info and iot_get_ca_certificate now copy into a caller- provided char *buf, size_t buf_len instead of returning pal-allocated strings, matching the iot_client_get_session_token convention — no heap ownership passes to the caller. The single-field iot_qrcode_response_t struct is removed. Both return OPRT_INVALID_RESULT when the buffer is too small.

iot_get_ca_certificate now also returns OPRT_INVALID_RESULT (with a log) when the server has no CA certificate for the endpoint — previously an empty string came back as success.

Examples migrated: scan-by-app demos use a stack buffer; the dp-management demo's ensure_mqtt_ca keeps the cert in a static buffer that outlives client->cacert and drops its free-at-shutdown bookkeeping.

Reference docs, the TLS guide snippet, and the scan-by-app tutorial follow the new signatures; the accompanying doc-review corrections to these three pages (library name, iot_init prerequisite, log_level_t note, qrcode request fields, mqtt_auto_connect init scope) ride along here.