### PR TITLE
fix(iot-client): send the region codes and endpoint keys IoT DNS accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Examples — music play demo (`tai_music_play_demo`).
+- Examples — music play demo (`tai_music_play_demo`)(#15).
   - New POSIX example `examples/posix/ai/rtc-tcp-client/music_play_demo.c` that
     sends a text query triggering the server's music skill, parses the returned
     audio metadata (artist / album / song / url), prints it, and downloads the
@@ -71,6 +71,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tuya-ble and common. Log-only — no behaviour change.
 
 ### Fixed
+
+- iot-client — US-East (`UEAZ`) and West-Europe (`WEAZ`) never resolved an MQTT
+  broker(#15). `iot_region_to_string()` sent the enum name as the `region` field
+  of `POST /v2/url_config`, but the service knows those two by their two-letter
+  activation-token prefix, `UE` and `WE`. The other five regions were correct.
+  - It failed silently: an unknown region is answered with HTTP 200 minus the
+    endpoint objects, so the query returned `OPRT_OK` and `mqtt_url` stayed empty
+    with no log line, surfacing only as a refused MQTT connect. A missing
+    endpoint now warns — which is also how the one remaining gap shows up:
+    West-Europe publishes no `httpsUrl`, so ATOP there still falls back to the
+    compile-time `IOT_WEAZ_HOST`.
+  - The queried keys are now `IOT_DNS_KEY_*` constants in `iot_dns.h` rather than
+    literals repeated across the three query sites, each of which also has to
+    compare the key back against the response.
+  - `iot_region_to_string()` moved to `iot_dns.c` beside `iot_region_to_host()`,
+    and `dns_test.c` pins the table as the inverse of `__token_to_region()` in
+    `iot_on_boarding.c` — those drifting apart is what caused this.
 
 - Examples — the tool-less rtc-tcp-client demos answer MCP requests correctly.
   text_chat, audio_chat, edu_camera and music_play each answered every

--- a/modules/iot-client/src/iot_client.c
+++ b/modules/iot-client/src/iot_client.c
@@ -32,20 +32,6 @@ static const char *iot_env_to_string(iot_env_t env)
     return env == PRE ? "pre" : "prod";
 }
 
-static const char *iot_region_to_string(iot_region_t region)
-{
-    switch (region) {
-        case AY:   return "AY";
-        case AZ:   return "AZ";
-        case UEAZ: return "UEAZ";
-        case EU:   return "EU";
-        case WEAZ: return "WEAZ";
-        case IN:   return "IN";
-        case SG:   return "SG";
-        default:   return NULL;
-    }
-}
-
 static int parse_host_port(const char *url, char *host_out, size_t host_len, uint16_t *port_out)
 {
     const char *p = url;
@@ -103,10 +89,11 @@ void iot_client_resolve_atop_host(iot_client_t *client, char *host_out, size_t h
 
 static int iot_client_dns_resolve(iot_client_t *client)
 {
-    const char *mqtt_dns_key = client->mqtt_disable_tls ? "mqttUrl" : "mqttsUrl";
+    const char *mqtt_dns_key = client->mqtt_disable_tls ? IOT_DNS_KEY_MQTT
+                                                        : IOT_DNS_KEY_MQTTS;
     iot_dns_config_item_t dns_keys[] = {
         { .key = mqtt_dns_key },
-        { .key = "httpsUrl" },
+        { .key = IOT_DNS_KEY_HTTPS },
     };
     iot_dns_url_config_request_t dns_req = {
         .cacert = client->cacert,
@@ -138,18 +125,32 @@ static int iot_client_dns_resolve(iot_client_t *client)
             } else {
                 log_info("IoT DNS %s: %s", mqtt_dns_key, client->mqtt_url);
             }
-        } else if (strcmp(dns_resp.endpoints[i].key, "httpsUrl") == 0) {
+        } else if (strcmp(dns_resp.endpoints[i].key, IOT_DNS_KEY_HTTPS) == 0) {
             const char *addr = dns_resp.endpoints[i].addr;
             int sn = snprintf(client->https_url, sizeof(client->https_url), "%s", addr);
             if (sn < 0 || (size_t)sn >= sizeof(client->https_url)) {
                 client->https_url[0] = '\0';
-                log_warn("IoT DNS httpsUrl too long, ignored");
+                log_warn("IoT DNS %s too long, ignored", IOT_DNS_KEY_HTTPS);
             } else {
-                log_info("IoT DNS httpsUrl: %s", client->https_url);
+                log_info("IoT DNS %s: %s", IOT_DNS_KEY_HTTPS, client->https_url);
             }
         }
     }
     iot_dns_url_config_response_free(client->pal, &dns_resp);
+
+    /* A key we asked for but did not get back is not an HTTP error: the service
+     * answers 200 with ttl/caArr and simply omits the endpoint object (that is
+     * how an unknown `region` presents). Say so here, or the only symptom is a
+     * refused MQTT connect several layers away, with nothing pointing back. */
+    if (client->mqtt_url[0] == '\0') {
+        log_warn("IoT DNS returned no %s for region=%s env=%s — MQTT stays unresolved",
+                 mqtt_dns_key, dns_req.region ? dns_req.region : "(unset)", dns_req.env);
+    }
+    if (client->https_url[0] == '\0') {
+        log_warn("IoT DNS returned no %s for region=%s env=%s — falling back to %s",
+                 IOT_DNS_KEY_HTTPS, dns_req.region ? dns_req.region : "(unset)",
+                 dns_req.env, iot_region_to_host(client->region, client->env));
+    }
 
     return OPRT_OK;
 }
@@ -596,7 +597,7 @@ IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, char *url, 
     }
 
     iot_dns_config_item_t dns_keys[] = {
-        { .key = "httpsUrl" },
+        { .key = IOT_DNS_KEY_HTTPS },
     };
     iot_dns_url_config_request_t dns_req = {
         .cacert       = request->cacert,
@@ -619,7 +620,7 @@ IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, char *url, 
     char host[64] = {0};
     uint16_t port = IOT_DEFAULT_PORT;
     for (int i = 0; i < dns_resp.endpoint_count; i++) {
-        if (strcmp(dns_resp.endpoints[i].key, "httpsUrl") == 0) {
+        if (strcmp(dns_resp.endpoints[i].key, IOT_DNS_KEY_HTTPS) == 0) {
             parse_host_port(dns_resp.endpoints[i].addr, host, sizeof(host), &port);
             break;
         }
@@ -627,7 +628,7 @@ IOT_API int iot_get_qrcode_info(const iot_qrcode_request_t *request, char *url, 
     iot_dns_url_config_response_free(pal, &dns_resp);
 
     if (host[0] == '\0') {
-        log_error("iot_get_qrcode_info: httpsUrl not found in DNS response");
+        log_error("iot_get_qrcode_info: %s not found in DNS response", IOT_DNS_KEY_HTTPS);
         return OPRT_COMMUNICATION_ERROR;
     }
 

--- a/modules/iot-client/src/iot_dns.c
+++ b/modules/iot-client/src/iot_dns.c
@@ -368,6 +368,27 @@ void iot_dns_ca_cert_response_free(const pal_t *pal, iot_dns_ca_cert_response_t 
     }
 }
 
+/* The wire spelling of a region for POST /v2/url_config. It is NOT the enum's
+ * own name: the service answers an unrecognised region with HTTP 200 and a body
+ * that simply omits the endpoint objects, so "UEAZ"/"WEAZ" (the enum spelling)
+ * resolved nothing at all and left mqtt_url empty with no error anywhere.
+ *
+ * The accepted set is the two-letter activation-token prefixes, so this must
+ * stay the exact inverse of __token_to_region() in iot_on_boarding.c. */
+const char *iot_region_to_string(iot_region_t region)
+{
+    switch (region) {
+        case AY:   return "AY";
+        case AZ:   return "AZ";
+        case UEAZ: return "UE";
+        case EU:   return "EU";
+        case WEAZ: return "WE";
+        case IN:   return "IN";
+        case SG:   return "SG";
+        default:   return NULL;
+    }
+}
+
 char *iot_region_to_host(iot_region_t region, iot_env_t env)
 {
     switch (env) {

--- a/modules/iot-client/src/iot_dns.h
+++ b/modules/iot-client/src/iot_dns.h
@@ -14,6 +14,21 @@
 #define IOT_DNS_MAX_ENDPOINTS 20
 #define IOT_DNS_MAX_CAS      4
 
+/* Endpoint keys the SDK asks POST /v2/url_config for. Named here because three
+ * call sites request them (iot_client_dns_resolve, iot_get_qrcode_info and the
+ * activation path in iot_on_boarding.c) and each one has to compare the key back
+ * against the response — a literal drifting in one of them resolves nothing, and
+ * the service reports that as HTTP 200 with the endpoint simply absent.
+ *
+ * These are the m1/a generation. The service also publishes an mqttsStdUrl /
+ * httpsStdUrl pair (m6/a6 hosts, MQTT on 8886, EC service CA rather than RSA);
+ * switching to it is a deployment decision, not a drop-in — it changes the broker
+ * port and makes iot_get_ca_certificate() succeed, which turns peer verification
+ * on for the first time. */
+#define IOT_DNS_KEY_MQTTS  "mqttsUrl"
+#define IOT_DNS_KEY_MQTT   "mqttUrl"
+#define IOT_DNS_KEY_HTTPS  "httpsUrl"
+
 /* ============================================================================
  * v1/dns_query
  * ============================================================================ */
@@ -140,5 +155,18 @@ int iot_dns_get_ca_cert(const pal_t *pal, const iot_dns_ca_cert_request_t *reque
 void iot_dns_ca_cert_response_free(const pal_t *pal, iot_dns_ca_cert_response_t *response);
 
 char *iot_region_to_host(iot_region_t region, iot_env_t env);
+
+/**
+ * @brief Region code as the IoT DNS service spells it (the `region` field of
+ *        POST /v2/url_config).
+ *
+ * These are the SAME two-letter codes that prefix an activation token, so this
+ * is the exact inverse of __token_to_region() in iot_on_boarding.c — keep the
+ * two in step. Note they are NOT the enum's own spelling: UEAZ is "UE" and WEAZ
+ * is "WE" on the wire.
+ *
+ * @return the code, or NULL for an unknown region.
+ */
+const char *iot_region_to_string(iot_region_t region);
 
 #endif /* __IOT_DNS_H__ */

--- a/modules/iot-client/src/iot_on_boarding.c
+++ b/modules/iot-client/src/iot_on_boarding.c
@@ -542,7 +542,8 @@ int on_boarding_with_qrcode(const pal_t *pal, on_boarding_config_t *on_boarding,
 
 
     // Query MQTT endpoint from IoT DNS service
-    const char *mqtt_dns_key = on_boarding->mqtt_disable_tls ? "mqttUrl" : "mqttsUrl";
+    const char *mqtt_dns_key = on_boarding->mqtt_disable_tls ? IOT_DNS_KEY_MQTT
+                                                            : IOT_DNS_KEY_MQTTS;
     iot_dns_config_item_t dns_keys[] = {
         { .key = mqtt_dns_key, .need_ca = !on_boarding->mqtt_disable_tls },
     };

--- a/modules/iot-client/test/dns_test.c
+++ b/modules/iot-client/test/dns_test.c
@@ -132,6 +132,43 @@ static int test_region_to_host_prod_mapping(void)
     return OPRT_OK;
 }
 
+/* The `region` field of POST /v2/url_config must carry the code the service
+ * knows, which is the two-letter activation-token prefix — NOT the enum's own
+ * name. Sending the enum spelling ("UEAZ"/"WEAZ") is answered with HTTP 200 and
+ * a body carrying ttl/caArr but no endpoint objects, so the query "succeeds"
+ * while resolving nothing and mqtt_url stays empty (regression: US-East and
+ * West-Europe devices never reached the MQTT connect at all).
+ *
+ * Keep this table identical to __token_to_region() in iot_on_boarding.c: the two
+ * are inverses, and it was them drifting apart that produced the bug. */
+static int test_region_to_string_wire_codes(void)
+{
+    static const struct { iot_region_t region; const char *code; } cases[] = {
+        { AY,   "AY" },
+        { AZ,   "AZ" },
+        { UEAZ, "UE" },
+        { EU,   "EU" },
+        { WEAZ, "WE" },
+        { IN,   "IN" },
+        { SG,   "SG" },
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        const char *code = iot_region_to_string(cases[i].region);
+        if (!code || strcmp(code, cases[i].code) != 0) {
+            printf("  region %d: expected \"%s\", got \"%s\"\n",
+                   (int)cases[i].region, cases[i].code, code ? code : "(null)");
+            return -1;
+        }
+    }
+    if (iot_region_to_string((iot_region_t)999) != NULL) {
+        printf("  an unknown region must map to NULL, not a wrong code\n");
+        return -1;
+    }
+    printf("  all %zu regions map to their wire code\n",
+           sizeof(cases) / sizeof(cases[0]));
+    return OPRT_OK;
+}
+
 /* ========== Parameter validation tests ========== */
 
 static int test_dns_query_null_params(void)
@@ -515,6 +552,64 @@ static int test_dns_query_multiple(void)
 
 /* ========== v2/url_config tests ========== */
 
+/* The keys the SDK itself asks for must resolve. Requesting a key the service
+ * does not publish is not an error: the response comes back 200 with the
+ * endpoint object simply absent, so a typo'd or stale key resolves nothing and
+ * every caller downstream sees an empty URL with no failure to trace.
+ *
+ * This pins IOT_DNS_KEY_* against the mock's catalog. It cannot prove the real
+ * service publishes them — only a live query does that — but it does fail the
+ * moment a constant is edited without the fixture being taught the new name,
+ * which is the prompt to go re-check the service. */
+static int test_url_config_sdk_keys_resolve(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_dns_config_item_t config[] = {
+        { .key = IOT_DNS_KEY_MQTTS },
+        { .key = IOT_DNS_KEY_HTTPS },
+        { .key = IOT_DNS_KEY_MQTT  },
+    };
+    const int n_keys = (int)(sizeof(config) / sizeof(config[0]));
+    iot_dns_url_config_request_t req = {
+        .host         = MOCK_HOST,
+        .port         = MOCK_PORT,
+        .region       = "AY",
+        .env          = "prod",
+        .uuid         = "test_uuid_12345678",
+        .config       = config,
+        .config_count = n_keys,
+    };
+    iot_dns_url_config_response_t resp = {0};
+
+    int ret = iot_dns_url_config(pal, &req, &resp);
+    if (ret != OPRT_OK) {
+        printf("  iot_dns_url_config failed: %d\n", ret);
+        return -1;
+    }
+
+    int rc = OPRT_OK;
+    for (int k = 0; k < n_keys; k++) {
+        const char *addr = NULL;
+        for (int i = 0; i < resp.endpoint_count; i++) {
+            if (strcmp(resp.endpoints[i].key, config[k].key) == 0) {
+                addr = resp.endpoints[i].addr;
+                break;
+            }
+        }
+        if (!addr || addr[0] == '\0') {
+            printf("  %s: NOT RESOLVED — the SDK asks for this key, so an empty\n"
+                   "      result here is a silently unreachable service\n",
+                   config[k].key);
+            rc = -1;
+        } else {
+            printf("  %-12s -> %s\n", config[k].key, addr);
+        }
+    }
+
+    iot_dns_url_config_response_free(pal, &resp);
+    return rc;
+}
+
 static int test_url_config_basic(void)
 {
     const pal_t *pal = get_default_pal();
@@ -694,6 +789,7 @@ int main(void)
 
     /* Static region -> host mapping */
     RUN_TEST(test_region_to_host_prod_mapping);
+    RUN_TEST(test_region_to_string_wire_codes);
 
     /* Parameter validation */
     RUN_TEST(test_dns_query_null_params);
@@ -720,6 +816,7 @@ int main(void)
     RUN_TEST(test_dns_query_multiple);
 
     /* v2/url_config */
+    RUN_TEST(test_url_config_sdk_keys_resolve);
     RUN_TEST(test_url_config_basic);
     RUN_TEST(test_url_config_with_region);
 

--- a/modules/iot-client/test/mock/dns_mock.py
+++ b/modules/iot-client/test/mock/dns_mock.py
@@ -74,6 +74,17 @@ URL_CONFIG_ENDPOINTS = {
         "addr": f"127.0.0.1:{os.getenv('ONBOARDING_MQTT_MOCK_PORT', '11884')}",
         "ips": ["127.0.0.1"],
     },
+    # The Std generation the real service also publishes. Not what the SDK asks
+    # for (see IOT_DNS_KEY_* in iot_dns.h), but served here so a build that
+    # switches to it still resolves against this fixture.
+    "mqttsStdUrl": {
+        "addr": f"127.0.0.1:{os.getenv('ONBOARDING_MQTT_MOCK_PORT', '11884')}",
+        "ips": ["127.0.0.1"],
+    },
+    "httpsStdUrl": {
+        "addr": "https://a1-test.example.com/d.json",
+        "ips": ["10.0.0.1", "10.0.0.2"],
+    },
 }
 
 


### PR DESCRIPTION
## Summary

Devices in US-East (`UEAZ`) and West-Europe (`WEAZ`) never resolved an MQTT
broker. `iot_region_to_string()` sent the enum's own name as the `region` field of
`POST /v2/url_config`, but the service knows those two regions by their two-letter
activation-token prefix — `UE` and `WE`. The other five regions were already
correct, which is why this went unnoticed.

It failed silently: an unrecognised `region` is answered with **HTTP 200** and a
body that simply omits the endpoint objects, so `iot_dns_url_config()` returned
`OPRT_OK`, the endpoint loop matched nothing, and `client->mqtt_url` stayed empty
without a log line. The only symptom was `iot_client_message_connect()` refusing
an empty URL, layers from the cause.

## Changes

- `iot_region_to_string()` emits the wire codes: `UEAZ` → `UE`, `WEAZ` → `WE`.
- It moves from `iot_client.c` to `iot_dns.c` beside `iot_region_to_host()`, so the
  two region mappings sit together — them living apart is what let this drift.
- A requested-but-missing endpoint now warns, naming the region and env.
- The queried keys become `IOT_DNS_KEY_*` constants in `iot_dns.h` instead of
  literals repeated across the three query sites (`iot_client_dns_resolve`,
  `iot_get_qrcode_info`, activation in `iot_on_boarding.c`), each of which also has
  to compare the key back against the response. The keys themselves are unchanged.
- Two regression tests in `dns_test.c`, plus the mock fixtures they need.

## Verification

Against the live service, all seven regions through the real `iot_client_init()`
path. The two that previously resolved nothing:

| region | `client->mqtt_url` |
|---|---|
| `UEAZ` | `mqtts://m1-ueaz.tuyaus.com:8883` |
| `WEAZ` | `mqtts://m1-weaz.tuyaeu.com:8883` |

Mutation testing confirms the new tests cover the change rather than just passing:
reverting `UEAZ` to its old spelling, or corrupting any `IOT_DNS_KEY_*`, fails
`iot_dns_test`. `httpsUrl` had **zero** coverage before this PR.

`iot_client_dns_resolve()` itself stays outside unit-test reach — it passes
`.host = NULL`, so the query always goes to the real `h1.iot-dns.com`. Covering it
needs a DNS-host injection point, out of scope here.

## Known gaps (all pre-existing, unchanged here)

- **West-Europe publishes no `httpsUrl`**; ATOP there falls back to the
  compile-time `IOT_WEAZ_HOST`. The new warning makes this visible.
- **MQTT peer verification is off in every region.**
  `iot_get_ca_certificate()` requests ECDSA only, while the legacy `m1.*:8883`
  brokers are RSA-signed, so it returns empty and callers connect unverified. A
  ~6-line ECDSA→RSA fallback would fix all seven without changing endpoints.
- The service also publishes `mqttsStdUrl` / `httpsStdUrl` (`m6`/`a6` hosts, MQTT
  on 8886, EC CA). Not adopted here: it moves the broker port and turns peer
  verification on for the first time, so it is a deployment decision. The new
  constants make that a one-line switch.

## Test plan

`ctest` 11/11; `iot_dns_test` 20 → 22 cases; live seven-region resolution check;
`dp_management_demo` connects and reports against the real cloud.
