### PR TITLE
feat: enable mqtt_auto_connect and bump atop activate API to v2.0

### DIFF
--- a/examples/esp-idf/pair/pair-by-ble/main/main.c
+++ b/examples/esp-idf/pair/pair-by-ble/main/main.c
@@ -167,6 +167,7 @@ static esp_err_t activate_device_with_ble_token(void)
         .timeout_ms = 120000,
         .env = PROD,
         .mqtt_disable_tls = false,
+        .mqtt_auto_connect = true,
         .cert_bundle_attach = (tls_cert_bundle_attach_fn)esp_crt_bundle_attach,
     };
 

--- a/modules/iot-client/src/atop.c
+++ b/modules/iot-client/src/atop.c
@@ -221,7 +221,7 @@ int atop_activate_request(const pal_t *pal, const activite_request_t *request, a
                                         .path = "/d.json",
                                         .timestamp = timestamp,
                                         .api = "thing.device.opensdk.active",
-                                        .version = "1.0",
+                                        .version = "2.0",
                                         .data = (void *)buffer,
                                         .datalen = offset,
                                         .user_data = request->user_data,


### PR DESCRIPTION
- Enable mqtt_auto_connect in BLE pairing example config
- Update atop activate request API version from 1.0 to 2.0