### PR TITLE
feat(ota): add firmware digest verification (MD5/HMAC-SHA256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     reset. Registered as the `unbind_demo` target in
     `examples/posix/CMakeLists.txt`.
 
+- iot-client — OTA firmware digest verification (`iot_ota_verify_*`).
+  - New streaming verifier API `iot_ota_verify_init` / `iot_ota_verify_update` /
+    `iot_ota_verify_finish` / `iot_ota_verify_abort` in `iot_ota.h`: the
+    application feeds downloaded firmware chunks into the context while
+    flashing, and `iot_ota_verify_finish()` compares the result against the
+    cloud-provided digest from `iot_ota_check_upgrade()`.
+  - Algorithm matches TuyaOpen's `tuya_ota.c`: when `hmac` is present the
+    expected value is `HMAC-SHA256(device secret_key,
+    UPPERCASE_hex(SHA-256(image)))` (the HMAC message is the 64-char
+    uppercase hex string of the SHA-256 digest, matching TuyaOpen's `hex2str`);
+    when only `md5` is present it falls back to plain MD5. Comparison is
+    case-insensitive. Neither digest present → `OPRT_NOT_SUPPORTED`;
+    mismatch → the new error code `OPRT_OTA_VERIFY_FAILED (-0x000D)`.
+  - An empty digest string counts as absent, so a blank `hmac` falls through
+    to a usable `md5` instead of failing the upgrade; a non-empty `hmac` of
+    the wrong length is still rejected rather than downgraded to `md5`.
+    `iot_ota_verify_init` does not write `*ctx_out` on any error path
+    (initialize it to NULL), so the skip path is `if (ctx != NULL)`;
+    `finish(NULL)` is a parameter error, not "skip".
+  - Both OTA demos now verify: the ESP-IDF demo checks the digest before
+    `esp_ota_set_boot_partition` and aborts on mismatch; the POSIX demo
+    re-reads the downloaded file, checking `ferror` so a read error is not
+    reported as a digest mismatch. Unit tests with Python-generated
+    known-answer vectors added as `iot_ota_verify_test`.
+
 - Examples — music play demo (`tai_music_play_demo`)(#15).
   - New POSIX example `examples/posix/ai/rtc-tcp-client/music_play_demo.c` that
     sends a text query triggering the server's music skill, parses the returned

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ set(IOT_CLIENT_SOURCES
     "${IOT_CLIENT_DIR}/src/iot_dp.c"
     "${IOT_CLIENT_DIR}/src/iot_on_boarding.c"
     "${IOT_CLIENT_DIR}/src/iot_ota.c"
+    "${IOT_CLIENT_DIR}/src/iot_ota_verify.c"
     "${IOT_CLIENT_DIR}/src/iot_pal_defaults.c"
     "${IOT_CLIENT_DIR}/src/mqtt.c"
 )
@@ -291,6 +292,7 @@ if(AGENTIC_KIT_BUILD_TESTS AND AGENTIC_KIT_ENABLE_PROJECT_TESTS)
     agentic_kit_add_iot_test(iot_on_boarding_test "${IOT_CLIENT_TESTS_DIR}/on_boarding_test.c")
     agentic_kit_add_iot_test(iot_dp_test "${IOT_CLIENT_TESTS_DIR}/iot_dp_test.c")
     agentic_kit_add_iot_test(iot_ota_test "${IOT_CLIENT_TESTS_DIR}/iot_ota_test.c")
+    agentic_kit_add_iot_test(iot_ota_verify_test "${IOT_CLIENT_TESTS_DIR}/iot_ota_verify_test.c")
 
     add_executable(tuya_ble_test
         "${TUYA_BLE_TESTS_DIR}/test_prov.c"

--- a/docs-site/docs/guides/ota-upgrade.md
+++ b/docs-site/docs/guides/ota-upgrade.md
@@ -42,6 +42,7 @@ SDK 只提供**云端协议原语**——版本上报、升级查询、状态回
 | `iot_ota_report_version` | `tuya.device.versions.update` (v4.1) | 上报当前固件版本（`iot_client_init` 会用 `iot_client_config_t.sw_ver` 自动调用，NULL 时用 SDK 默认 `IOT_SDK_SW_VER`） |
 | `iot_ota_check_upgrade` | `tuya.device.upgrade.get` (v4.4) | 查询是否有待升级固件，返回 URL / 版本 / 大小 / 哈希（云端与已上报的版本比较，不再传版本号） |
 | `iot_ota_report_status` | `tuya.device.upgrade.status.update` (v4.1) | 回报升级生命周期状态 |
+| `iot_ota_verify_init/update/finish` | — | 流式校验下载固件的 md5/hmac 摘要（见下文） |
 
 ### `iot_ota_check_upgrade` 返回的升级信息
 
@@ -70,6 +71,51 @@ typedef enum {
     OTA_STATUS_ERROR     = 4,  // 升级失败 / 异常
 } iot_ota_status_t;
 ```
+
+## 固件摘要校验（md5 / hmac）
+
+云端在升级信息里返回固件摘要（`info.hmac` 优先，否则 `info.md5`；字段缺失或为空串都算没有下发该摘要）。SDK 提供**流式校验 API**：应用在下载循环中把每个固件块喂给校验器，下载完成后 `iot_ota_verify_finish()` 比对云端摘要，不匹配返回 `OPRT_OTA_VERIFY_FAILED`。
+
+算法与 TuyaOpen 一致：
+
+```
+expected = HMAC-SHA256(key = 设备 secret_key,
+                       msg = UPPERCASE_hex(SHA-256(固件字节)))
+```
+
+注意 HMAC 的消息是 SHA-256 摘要的 **64 字符大写十六进制字符串**（与 TuyaOpen 的 `hex2str` 一致，不是小写，也不是原始 32 字节）。云端没有下发 `hmac`（字段缺失或为空串）时退化为 `MD5(固件字节)` 比对；但 `hmac` 非空而长度不对时 `init` 直接报错，不会降级到 `md5`。比较大小写不敏感。
+
+```c
+iot_ota_verify_ctx_t *ctx = NULL;
+int rc = iot_ota_verify_init(iot, &info, &ctx);
+if (rc != OPRT_OK && rc != OPRT_NOT_SUPPORTED) {
+    /* 摘要格式非法、内存不足等 —— 中止升级，上报 OTA_STATUS_ERROR */
+    return -1;
+}
+/* rc == OPRT_NOT_SUPPORTED: 云端没有摘要字段，ctx 保持 NULL，跳过校验
+ * （应用自行决定） */
+
+while ((n = read_firmware_chunk(buf)) > 0) {
+    if (ctx != NULL && iot_ota_verify_update(ctx, buf, n) != OPRT_OK) {
+        iot_ota_verify_abort(ctx);
+        return -1;
+    }
+    flash_write(buf, n);                  /* 与喂给校验器的数据一致 */
+}
+
+if (ctx != NULL) {
+    rc = iot_ota_verify_finish(ctx);      /* 内部释放 ctx */
+    if (rc != OPRT_OK) {
+        /* OPRT_OTA_VERIFY_FAILED: 固件被篡改/损坏 —— 中止，上报 OTA_STATUS_ERROR */
+        return -1;
+    }
+}
+```
+
+- 校验失败时**不要切换启动分区**，上报 `OTA_STATUS_ERROR` 后丢弃本次下载。
+- 下载中途失败用 `iot_ota_verify_abort(ctx)` 直接释放（不比对）。
+- `finish` 无论成败都会释放上下文，之后不要再使用；`finish(NULL)` 不是"跳过校验"，会返回参数错误，所以跳过校验的路径必须用 `if (ctx != NULL)` 把 `update`/`finish` 一起圈起来。
+- `init` 只要返回**非 `OPRT_OK` 且非 `OPRT_NOT_SUPPORTED`** 就必须中止升级，`ctx` 此时不会被写入（保持 NULL）；按这两个值分支，不要枚举具体错误码。
 
 ## 完整示例（ESP-IDF）
 
@@ -147,8 +193,8 @@ if (rc == OPRT_OK && info.has_upgrade) {
 /* 下载前上报"升级中" */
 iot_ota_report_status(iot, 0, OTA_STATUS_UPGRADING);
 
-/* 用 esp_http_client 下载 info.url，逐块 esp_ota_write */
-esp_err_t err = download_and_flash(info.url);
+/* 用 esp_http_client 下载 info.url，逐块 esp_ota_write + 摘要校验 */
+esp_err_t err = download_and_flash(iot, &info);
 iot_ota_upgrade_info_free(iot, &info);
 
 if (err != ESP_OK) {
@@ -164,23 +210,45 @@ esp_restart();
 `download_and_flash` 的核心流程（完整代码见 demo）：
 
 ```c
-static esp_err_t download_and_flash(const char *url)
+static esp_err_t download_and_flash(iot_client_t *iot,
+                                    const iot_ota_upgrade_info_t *info)
 {
     const esp_partition_t *part = esp_ota_get_next_update_partition(NULL);
 
+    /* 摘要校验上下文（云端无 md5/hmac 时返回 OPRT_NOT_SUPPORTED，verify 保持 NULL） */
+    iot_ota_verify_ctx_t *verify = NULL;
+    int vrc = iot_ota_verify_init(iot, info, &verify);
+    if (vrc != OPRT_OK && vrc != OPRT_NOT_SUPPORTED) {
+        ESP_LOGE(TAG, "iot_ota_verify_init failed: %d", vrc);
+        return ESP_FAIL;   /* 校验器建不起来 —— 不装这个固件 */
+    }
+
     esp_http_client_config_t http_cfg = {
-        .url              = url,
+        .url              = info->url,
         .timeout_ms       = 30000,
         .buffer_size      = 4096,
         .crt_bundle_attach = esp_crt_bundle_attach,  /* 公共 CA 包 */
     };
-    /* ... open / fetch headers / 检查 200 ... */
+    /* ... open / fetch headers / 检查 200；任何失败路径都要 iot_ota_verify_abort(verify) ... */
 
     esp_ota_handle_t handle;
     esp_ota_begin(part, OTA_WITH_SEQUENTIAL_WRITES, &handle);
 
     while ((n = esp_http_client_read(client, buf, sizeof(buf))) > 0) {
-        esp_ota_write(handle, buf, n);   /* 逐块写入 */
+        if (verify != NULL) {
+            iot_ota_verify_update(verify, (const uint8_t *)buf, n);  /* 与写入数据一致 */
+        }
+        esp_ota_write(handle, buf, n);                               /* 逐块写入 */
+    }
+
+    /* 切分区前校验云端摘要；不匹配则 esp_ota_abort 放弃 */
+    if (verify != NULL) {
+        vrc = iot_ota_verify_finish(verify);   /* 内部释放 verify */
+        if (vrc != OPRT_OK) {
+            ESP_LOGE(TAG, "Firmware digest mismatch (rc=%d)", vrc);
+            esp_ota_abort(handle);
+            return ESP_FAIL;
+        }
     }
 
     esp_ota_end(handle);
@@ -223,4 +291,4 @@ idf flash monitor
 - **SDK 不下载/不烧写**——`iot_ota` 只负责云端协议；下载校验、分区管理、防回滚全部由应用实现。
 - **栈要足够大**——TLS 握手 + HTTP 缓冲 + `esp_ota_write` 需要较大栈空间（demo 用 16KB）。
 - **回报时机**——`UPGRADING` 在下载前、`COMPLETE` 在重启前、`ERROR` 在失败时；漏报会导致云端升级面板状态不准。
-- **MD5/HMAC 可选校验**——`info.md5` / `info.hmac` 可能为 NULL；若存在，建议在 `esp_ota_end` 后做一次校验再切分区。
+- **MD5/HMAC 摘要校验**——`iot_ota_verify_init/update/finish` 在下载时流式计算摘要，`esp_ota_set_boot_partition` **之前**完成校验；不匹配必须中止升级（见上文「固件摘要校验」）。

--- a/examples/esp-idf/components/agentic_kit/CMakeLists.txt
+++ b/examples/esp-idf/components/agentic_kit/CMakeLists.txt
@@ -21,6 +21,7 @@ set(AK_SRCS
     ${AK_DIR}/modules/iot-client/src/iot_dp.c
     ${AK_DIR}/modules/iot-client/src/iot_on_boarding.c
     ${AK_DIR}/modules/iot-client/src/iot_ota.c
+    ${AK_DIR}/modules/iot-client/src/iot_ota_verify.c
     ${AK_DIR}/modules/iot-client/src/mqtt.c
 
     # tuya-ble

--- a/examples/esp-idf/ota-demo/main/main.c
+++ b/examples/esp-idf/ota-demo/main/main.c
@@ -103,13 +103,28 @@ static void wifi_init_sta(void)
 /* Firmware download + flash (ESP-IDF esp_ota_* + esp_http_client)         */
 /* ----------------------------------------------------------------------- */
 
-static esp_err_t download_and_flash(const char *url)
+static esp_err_t download_and_flash(iot_client_t *iot,
+                                    const iot_ota_upgrade_info_t *info)
 {
+    const char *url = info->url;
     ESP_LOGI(TAG, "Starting firmware download: %s", url);
+
+    /* Digest verification context (NULL = cloud sent no digest; skip check) */
+    iot_ota_verify_ctx_t *verify = NULL;
+    int vrc = iot_ota_verify_init(iot, info, &verify);
+    if (vrc == OPRT_OK) {
+        ESP_LOGI(TAG, "Digest verification enabled");
+    } else if (vrc == OPRT_NOT_SUPPORTED) {
+        ESP_LOGW(TAG, "Cloud provided no md5/hmac — downloading without digest check");
+    } else {
+        ESP_LOGE(TAG, "iot_ota_verify_init failed: %d", vrc);
+        return ESP_FAIL;
+    }
 
     const esp_partition_t *update_part = esp_ota_get_next_update_partition(NULL);
     if (update_part == NULL) {
         ESP_LOGE(TAG, "No OTA partition available");
+        iot_ota_verify_abort(verify);
         return ESP_FAIL;
     }
     ESP_LOGI(TAG, "Update partition: %s @ 0x%08lx", update_part->label,
@@ -127,6 +142,7 @@ static esp_err_t download_and_flash(const char *url)
     esp_http_client_handle_t client = esp_http_client_init(&http_cfg);
     if (client == NULL) {
         ESP_LOGE(TAG, "Failed to init HTTP client");
+        iot_ota_verify_abort(verify);
         return ESP_FAIL;
     }
 
@@ -134,6 +150,7 @@ static esp_err_t download_and_flash(const char *url)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to open HTTP connection: %s", esp_err_to_name(err));
         esp_http_client_cleanup(client);
+        iot_ota_verify_abort(verify);
         return err;
     }
 
@@ -145,6 +162,7 @@ static esp_err_t download_and_flash(const char *url)
         ESP_LOGE(TAG, "HTTP error: status %d", status_code);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
+        iot_ota_verify_abort(verify);
         return ESP_FAIL;
     }
 
@@ -155,6 +173,7 @@ static esp_err_t download_and_flash(const char *url)
         ESP_LOGE(TAG, "esp_ota_begin failed: %s", esp_err_to_name(err));
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
+        iot_ota_verify_abort(verify);
         return err;
     }
 
@@ -164,6 +183,7 @@ static esp_err_t download_and_flash(const char *url)
         esp_ota_abort(update_handle);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
+        iot_ota_verify_abort(verify);
         return ESP_ERR_NO_MEM;
     }
 
@@ -178,10 +198,21 @@ static esp_err_t download_and_flash(const char *url)
             esp_ota_abort(update_handle);
             esp_http_client_close(client);
             esp_http_client_cleanup(client);
+            iot_ota_verify_abort(verify);
             return ESP_FAIL;
         }
         if (read_len == 0) {
             break;  /* EOF */
+        }
+
+        if (verify != NULL && iot_ota_verify_update(verify, (const uint8_t *)buf, read_len) != OPRT_OK) {
+            ESP_LOGE(TAG, "Digest update failed");
+            free(buf);
+            esp_ota_abort(update_handle);
+            esp_http_client_close(client);
+            esp_http_client_cleanup(client);
+            iot_ota_verify_abort(verify);
+            return ESP_FAIL;
         }
 
         err = esp_ota_write(update_handle, buf, read_len);
@@ -191,6 +222,7 @@ static esp_err_t download_and_flash(const char *url)
             esp_ota_abort(update_handle);
             esp_http_client_close(client);
             esp_http_client_cleanup(client);
+            iot_ota_verify_abort(verify);
             return err;
         }
 
@@ -212,10 +244,23 @@ static esp_err_t download_and_flash(const char *url)
     if (content_length > 0 && total_read != content_length) {
         ESP_LOGE(TAG, "Size mismatch: read %d, expected %d", total_read, content_length);
         esp_ota_abort(update_handle);
+        iot_ota_verify_abort(verify);
         return ESP_FAIL;
     }
 
     ESP_LOGI(TAG, "Download complete: %d bytes", total_read);
+
+    /* Verify the cloud digest before making the image bootable */
+    if (verify != NULL) {
+        vrc = iot_ota_verify_finish(verify);  /* frees verify */
+        verify = NULL;
+        if (vrc != OPRT_OK) {
+            ESP_LOGE(TAG, "Firmware digest mismatch (rc=%d) — aborting upgrade", vrc);
+            esp_ota_abort(update_handle);
+            return ESP_FAIL;
+        }
+        ESP_LOGI(TAG, "Firmware digest verified");
+    }
 
     err = esp_ota_end(update_handle);
     if (err != ESP_OK) {
@@ -346,8 +391,8 @@ void app_main(void)
         ESP_LOGW(TAG, "Failed to report UPGRADING status: %d (continuing)", rc);
     }
 
-    /* 5. Download and flash firmware */
-    esp_err_t err = download_and_flash(info.url);
+    /* 5. Download and flash firmware (verifies cloud md5/hmac before boot switch) */
+    esp_err_t err = download_and_flash(iot, &info);
     iot_ota_upgrade_info_free(iot, &info);
 
     if (err != ESP_OK) {

--- a/examples/posix/ota-demo/ota_demo.c
+++ b/examples/posix/ota-demo/ota_demo.c
@@ -43,6 +43,56 @@
 /* Firmware download (simulated — writes to a local file)                  */
 /* ----------------------------------------------------------------------- */
 
+static int verify_firmware(iot_client_t *client, const char *path,
+                           const iot_ota_upgrade_info_t *info)
+{
+    iot_ota_verify_ctx_t *ctx = NULL;
+    int rc = iot_ota_verify_init(client, info, &ctx);
+    if (rc == OPRT_NOT_SUPPORTED) {
+        printf("[%s] cloud provided no md5/hmac — skipping digest check\n", TAG);
+        return 0;
+    }
+    if (rc != OPRT_OK) {
+        fprintf(stderr, "[%s] iot_ota_verify_init failed: %d\n", TAG, rc);
+        return -1;
+    }
+
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        fprintf(stderr, "[%s] cannot open %s for verification\n", TAG, path);
+        iot_ota_verify_abort(ctx);
+        return -1;
+    }
+
+    uint8_t buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
+        if (iot_ota_verify_update(ctx, buf, n) != OPRT_OK) {
+            fprintf(stderr, "[%s] digest update failed\n", TAG);
+            fclose(f);
+            iot_ota_verify_abort(ctx);
+            return -1;
+        }
+    }
+    /* fread() returns 0 for both EOF and I/O error; without this the digest
+     * would be computed over a truncated prefix and reported as a mismatch. */
+    if (ferror(f)) {
+        fprintf(stderr, "[%s] read error on %s\n", TAG, path);
+        fclose(f);
+        iot_ota_verify_abort(ctx);
+        return -1;
+    }
+    fclose(f);
+
+    rc = iot_ota_verify_finish(ctx);
+    if (rc == OPRT_OK) {
+        printf("[%s] firmware digest verified\n", TAG);
+        return 0;
+    }
+    fprintf(stderr, "[%s] firmware digest mismatch (rc=%d)\n", TAG, rc);
+    return -1;
+}
+
 static int download_firmware(const char *url, const char *out_path,
                              long expected_size)
 {
@@ -152,8 +202,9 @@ int demo_ota_run(const char *devid, const char *secret_key, const char *local_ke
         snprintf(out_path, sizeof(out_path), "firmware_%s.bin",
                  info.version ? info.version : "unknown");
 
-        if (download_firmware(info.url, out_path, info.file_size) != 0) {
-            fprintf(stderr, "[%s] firmware download failed\n", TAG);
+        if (download_firmware(info.url, out_path, info.file_size) != 0 ||
+            verify_firmware(client, out_path, &info) != 0) {
+            fprintf(stderr, "[%s] firmware download/verify failed\n", TAG);
             printf("[%s] reporting FAILURE status...\n", TAG);
             iot_ota_report_status(client, info.channel, OTA_STATUS_ERROR);
             result = -1;

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -26,6 +26,9 @@
 #define OPRT_MALLOC_FAILED            (-0x0006) //-6, Memory allocation failed
 #define OPRT_TLS_HANDSHAKE_FAILED     (-0x0007) //-7, TLS handshake failed
 
+/* -0x0008..-0x000C are used by iot_dp.h (DP error codes) */
+#define OPRT_OTA_VERIFY_FAILED        (-0x000D) //-13, OTA firmware digest mismatch
+
 /* ---- Logging subsystem ----
  * The IoT SDK shares the process-wide log facade (see log.h).
  * To redirect output: log_set_handler(my_fn);

--- a/modules/iot-client/include/iot_ota.h
+++ b/modules/iot-client/include/iot_ota.h
@@ -132,4 +132,78 @@ OTA_API int iot_ota_report_status(iot_client_t *client, int channel,
  */
 OTA_API void iot_ota_upgrade_info_free(iot_client_t *client, iot_ota_upgrade_info_t *info);
 
+/* ============================================================================
+ * Firmware digest verification (MD5 / HMAC-SHA256)
+ * ============================================================================ */
+
+/** Opaque streaming digest context (allocated by iot_ota_verify_init). */
+typedef struct iot_ota_verify_ctx iot_ota_verify_ctx_t;
+
+/**
+ * @brief Start verifying a firmware image against the cloud digest.
+ *
+ * Algorithm selection (following TuyaOpen tuya_ota.c):
+ * - If @p info->hmac is a non-empty string: expected value is
+ *   HMAC-SHA256(key = client->secret_key,
+ *               msg = UPPERCASE_hex(SHA-256(firmware))) as 64 hex chars.
+ * - Else if @p info->md5 is a non-empty string: expected value is
+ *   MD5(firmware) as 32 hex chars.
+ * - Else: OPRT_NOT_SUPPORTED (nothing to verify against). The cloud sends ""
+ *   for a digest it has not configured, so an empty string counts as absent
+ *   and falls through to the next algorithm.
+ *
+ * A non-empty digest of the wrong length is OPRT_INVALID_PARAMETER, never a
+ * silent downgrade to the weaker algorithm.
+ *
+ * On any error return, @p ctx_out is not written — initialize it to NULL
+ * before the call. The returned context borrows client->pal: call
+ * iot_ota_verify_finish() or iot_ota_verify_abort() before
+ * iot_client_deinit().
+ *
+ * @param[in]  client   IoT client instance (provides secret_key + allocator)
+ * @param[in]  info     Upgrade info returned by iot_ota_check_upgrade()
+ * @param[out] ctx_out  Initialized verification context
+ * @return OPRT_OK on success, OPRT_NOT_SUPPORTED if neither digest is present
+ *         (absent or empty), OPRT_INVALID_PARAMETER on bad args or on a
+ *         non-empty digest of the wrong length
+ */
+OTA_API int iot_ota_verify_init(iot_client_t *client,
+                                const iot_ota_upgrade_info_t *info,
+                                iot_ota_verify_ctx_t **ctx_out);
+
+/**
+ * @brief Feed a firmware chunk into the digest.
+ *
+ * Call for every chunk in download order; the chunk order and boundaries do
+ * not affect the result.
+ *
+ * @param ctx  Verification context
+ * @param data Firmware bytes
+ * @param len  Number of bytes
+ * @return OPRT_OK on success, error code on failure
+ */
+OTA_API int iot_ota_verify_update(iot_ota_verify_ctx_t *ctx,
+                                  const uint8_t *data, size_t len);
+
+/**
+ * @brief Finish verification and free the context.
+ *
+ * The context is freed on every path (success or failure); do not use it
+ * again after this call.
+ *
+ * @param ctx Verification context
+ * @return OPRT_OK if the digest matches, OPRT_OTA_VERIFY_FAILED on mismatch,
+ *         error code on internal failure
+ */
+OTA_API int iot_ota_verify_finish(iot_ota_verify_ctx_t *ctx);
+
+/**
+ * @brief Free a verification context without checking the digest.
+ *
+ * For download-failure paths where verification will never complete.
+ *
+ * @param ctx Verification context (NULL is a safe no-op)
+ */
+OTA_API void iot_ota_verify_abort(iot_ota_verify_ctx_t *ctx);
+
 #endif /* _IOT_OTA_H_ */

--- a/modules/iot-client/src/iot_ota_verify.c
+++ b/modules/iot-client/src/iot_ota_verify.c
@@ -1,0 +1,248 @@
+#include "iot_ota.h"
+#include "iot_config_defaults.h"
+
+#include <mbedtls/md5.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/md.h>
+
+#include <string.h>
+
+/**
+ * @file iot_ota_verify.c
+ * @brief Streaming firmware digest verification for OTA downloads.
+ *
+ * Replicates the validation performed by TuyaOpen's tuya_ota.c:
+ *   expected = HMAC-SHA256(device secret_key, UPPERCASE_hex(SHA-256(image)))
+ * i.e. the HMAC message is the 64-character hex STRING of the SHA-256
+ * digest (uppercase, matching TuyaOpen's hex2str), not the raw 32-byte
+ * digest. MD5 is provided as a fallback for upgrade responses that carry
+ * no "hmac" field.
+ */
+
+#define OTA_MD5_HEX_LEN    32
+#define OTA_SHA256_HEX_LEN 64
+
+typedef enum {
+    OTA_VERIFY_HMAC_SHA256,
+    OTA_VERIFY_MD5,
+} ota_verify_algo_t;
+
+struct iot_ota_verify_ctx {
+    const pal_t *pal;          /* borrowed from client */
+    ota_verify_algo_t algo;
+    char expected[OTA_SHA256_HEX_LEN + 1]; /* lowercased cloud value */
+    union {
+        mbedtls_sha256_context sha256;
+        mbedtls_md5_context    md5;
+    } digest;
+    uint8_t key[32];           /* secret_key copy (HMAC path) */
+    size_t  key_len;
+};
+
+static void bytes_to_hex_lower(const uint8_t *src, size_t len, char *dst)
+{
+    static const char hexdig[] = "0123456789abcdef";
+    for (size_t i = 0; i < len; i++) {
+        dst[i * 2]     = hexdig[src[i] >> 4];
+        dst[i * 2 + 1] = hexdig[src[i] & 0x0F];
+    }
+    dst[len * 2] = '\0';
+}
+
+/* TuyaOpen's hex2str produces UPPERCASE hex; the cloud's HMAC is computed
+ * over the uppercase hex string of the SHA-256 digest, so we must match. */
+static void bytes_to_hex_upper(const uint8_t *src, size_t len, char *dst)
+{
+    static const char hexdig[] = "0123456789ABCDEF";
+    for (size_t i = 0; i < len; i++) {
+        dst[i * 2]     = hexdig[src[i] >> 4];
+        dst[i * 2 + 1] = hexdig[src[i] & 0x0F];
+    }
+    dst[len * 2] = '\0';
+}
+
+static void str_to_lower(char *s)
+{
+    for (; *s; s++) {
+        if (*s >= 'A' && *s <= 'Z') {
+            *s += 'a' - 'A';
+        }
+    }
+}
+
+/* Compare without early exit on the first differing byte. */
+static int hex_equal_consttime(const char *a, const char *b, size_t len)
+{
+    unsigned char diff = 0;
+    for (size_t i = 0; i < len; i++) {
+        diff |= (unsigned char)(a[i] ^ b[i]);
+    }
+    return diff == 0;
+}
+
+static void ctx_free(iot_ota_verify_ctx_t *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+    if (ctx->algo == OTA_VERIFY_HMAC_SHA256) {
+        mbedtls_sha256_free(&ctx->digest.sha256);
+    } else if (ctx->algo == OTA_VERIFY_MD5) {
+        mbedtls_md5_free(&ctx->digest.md5);
+    }
+    ctx->pal->free(ctx);
+}
+
+int iot_ota_verify_init(iot_client_t *client,
+                        const iot_ota_upgrade_info_t *info,
+                        iot_ota_verify_ctx_t **ctx_out)
+{
+    if (client == NULL || info == NULL || ctx_out == NULL || client->pal == NULL) {
+        return OPRT_INVALID_PARAMETER;
+    }
+
+    const char *expected = NULL;
+    size_t expected_len = 0;
+    ota_verify_algo_t algo;
+
+    /* The cloud sends "" for a digest it has not configured, so an empty string
+     * means absent: fall through to the next algorithm instead of rejecting the
+     * upgrade. A non-empty value of the wrong length stays a hard error -- a
+     * malformed hmac must never silently downgrade to the weaker md5. */
+    if (info->hmac != NULL && info->hmac[0] != '\0') {
+        algo = OTA_VERIFY_HMAC_SHA256;
+        expected = info->hmac;
+        expected_len = strlen(expected);
+        if (expected_len != OTA_SHA256_HEX_LEN) {
+            return OPRT_INVALID_PARAMETER;
+        }
+    } else if (info->md5 != NULL && info->md5[0] != '\0') {
+        algo = OTA_VERIFY_MD5;
+        expected = info->md5;
+        expected_len = strlen(expected);
+        if (expected_len != OTA_MD5_HEX_LEN) {
+            return OPRT_INVALID_PARAMETER;
+        }
+    } else {
+        return OPRT_NOT_SUPPORTED;
+    }
+
+    const pal_t *pal = client->pal;
+    iot_ota_verify_ctx_t *ctx = pal->malloc(sizeof(*ctx));
+    if (ctx == NULL) {
+        return OPRT_MALLOC_FAILED;
+    }
+    memset(ctx, 0, sizeof(*ctx));
+
+    ctx->pal = pal;
+    ctx->algo = algo;
+    memcpy(ctx->expected, expected, expected_len);
+    ctx->expected[expected_len] = '\0';
+    str_to_lower(ctx->expected);
+
+    int ret = 0;
+    if (algo == OTA_VERIFY_HMAC_SHA256) {
+        ctx->key_len = strlen(client->secret_key);
+        if (ctx->key_len == 0 || ctx->key_len > sizeof(ctx->key)) {
+            pal->free(ctx);
+            return OPRT_INVALID_PARAMETER;
+        }
+        memcpy(ctx->key, client->secret_key, ctx->key_len);
+
+        mbedtls_sha256_init(&ctx->digest.sha256);
+        ret = mbedtls_sha256_starts(&ctx->digest.sha256, 0);
+        if (ret != 0) {
+            log_error("sha256 starts failed: -0x%04x", -ret);
+            ctx_free(ctx);
+            return ret;
+        }
+    } else {
+        mbedtls_md5_init(&ctx->digest.md5);
+        ret = mbedtls_md5_starts(&ctx->digest.md5);
+        if (ret != 0) {
+            log_error("md5 starts failed: -0x%04x", -ret);
+            ctx_free(ctx);
+            return ret;
+        }
+    }
+
+    *ctx_out = ctx;
+    return OPRT_OK;
+}
+
+int iot_ota_verify_update(iot_ota_verify_ctx_t *ctx,
+                          const uint8_t *data, size_t len)
+{
+    if (ctx == NULL || (len > 0 && data == NULL)) {
+        return OPRT_INVALID_PARAMETER;
+    }
+
+    int ret;
+    if (ctx->algo == OTA_VERIFY_HMAC_SHA256) {
+        ret = mbedtls_sha256_update(&ctx->digest.sha256, data, len);
+    } else {
+        ret = mbedtls_md5_update(&ctx->digest.md5, data, len);
+    }
+    if (ret != 0) {
+        log_error("digest update failed: -0x%04x", -ret);
+        return ret;
+    }
+    return OPRT_OK;
+}
+
+int iot_ota_verify_finish(iot_ota_verify_ctx_t *ctx)
+{
+    if (ctx == NULL) {
+        return OPRT_INVALID_PARAMETER;
+    }
+
+    char actual[OTA_SHA256_HEX_LEN + 1];
+    int ret = OPRT_OK;
+
+    if (ctx->algo == OTA_VERIFY_HMAC_SHA256) {
+        uint8_t sha[32];
+        ret = mbedtls_sha256_finish(&ctx->digest.sha256, sha);
+        if (ret != 0) {
+            log_error("sha256 finish failed: -0x%04x", -ret);
+            ctx_free(ctx);
+            return ret;
+        }
+
+        /* HMAC message is the UPPERCASE hex string of the SHA-256 digest
+         * (matches TuyaOpen's hex2str which produces A-F, not a-f). */
+        char sha_hex[OTA_SHA256_HEX_LEN + 1];
+        bytes_to_hex_upper(sha, sizeof(sha), sha_hex);
+
+        uint8_t mac[32];
+        const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+        ret = mbedtls_md_hmac(md_info, ctx->key, ctx->key_len,
+                              (const uint8_t *)sha_hex, OTA_SHA256_HEX_LEN, mac);
+        if (ret != 0) {
+            log_error("hmac failed: -0x%04x", -ret);
+            ctx_free(ctx);
+            return ret;
+        }
+        bytes_to_hex_lower(mac, sizeof(mac), actual);
+    } else {
+        uint8_t md5[16];
+        ret = mbedtls_md5_finish(&ctx->digest.md5, md5);
+        if (ret != 0) {
+            log_error("md5 finish failed: -0x%04x", -ret);
+            ctx_free(ctx);
+            return ret;
+        }
+        bytes_to_hex_lower(md5, sizeof(md5), actual);
+    }
+
+    size_t expected_len = strlen(ctx->expected);
+    int match = (expected_len == strlen(actual)) &&
+                hex_equal_consttime(ctx->expected, actual, expected_len);
+
+    ctx_free(ctx);
+    return match ? OPRT_OK : OPRT_OTA_VERIFY_FAILED;
+}
+
+void iot_ota_verify_abort(iot_ota_verify_ctx_t *ctx)
+{
+    ctx_free(ctx);
+}

--- a/modules/iot-client/test/iot_ota_verify_test.c
+++ b/modules/iot-client/test/iot_ota_verify_test.c
@@ -1,0 +1,366 @@
+/**
+ * @file iot_ota_verify_test.c
+ * @brief Unit tests for the OTA firmware digest verifier (iot_ota_verify_*).
+ *
+ * Known-answer vectors generated with Python:
+ *   key  = b"test_secret_key_0123456789abcd"
+ *   data = bytes((i * 7 + 3) & 0xFF for i in range(1000))
+ *   md5_hex  = hashlib.md5(data).hexdigest()
+ *   hmac_hex = hmac.new(key, hashlib.sha256(data).hexdigest().upper().encode(),
+ *                       hashlib.sha256).hexdigest()
+ *
+ * No mock server needed: iot_client_t is a public struct, so a stack instance
+ * with .pal and .secret_key set is sufficient.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "iot_client.h"
+#include "iot_ota.h"
+#include "iot_config_defaults.h"
+
+#define TEST_KEY  "test_secret_key_0123456789abcd"  /* 30 chars + NUL fits secret_key[32] */
+#define DATA_LEN  1000
+
+/* Known-answer vectors (see file header for generation recipe). */
+#define KAT_MD5      "10046f077f2082ac19676b8079f1cb1a"
+#define KAT_MD5_BAD  "7a0d252e3886d50cf0f0963874e887a3"
+#define KAT_HMAC     "9fe946a5023ee5e5d00faf7ab3e67658a9e26291f4cfb453ae3a0c06a1808f63"
+#define KAT_HMAC_UP  "9FE946A5023EE5E5D00FAF7AB3E67658A9E26291F4CFB453AE3A0C06A1808F63"
+#define KAT_HMAC_BAD "e432f4036382824babfa9e2290b5143d7816ac9ae985f24d6fac065fd809daa8"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define RUN_TEST(fn)                                       \
+    do {                                                   \
+        tests_run++;                                       \
+        printf("\n--- [%d] %s ---\n", tests_run, #fn);     \
+        if ((fn)() == 0) {                                 \
+            tests_passed++;                                \
+            printf("  PASS\n");                            \
+        } else {                                           \
+            printf("  FAIL\n");                            \
+        }                                                  \
+    } while (0)
+
+static uint8_t g_data[DATA_LEN];
+static iot_client_t g_client;
+
+static void test_setup(void)
+{
+    for (int i = 0; i < DATA_LEN; i++) {
+        g_data[i] = (uint8_t)((i * 7 + 3) & 0xFF);
+    }
+}
+
+/* Corrupt one byte of a private copy; g_data stays intact so a test that
+ * returns early cannot leave the shared image corrupted for later tests. */
+static void corrupt_byte(uint8_t *image, size_t offset)
+{
+    image[offset] ^= 1;
+}
+
+static int test_hmac_match_single_update(void)
+{
+    iot_ota_upgrade_info_t info = { .hmac = (char *)KAT_HMAC };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK || ctx == NULL) {
+        printf("  init failed: %d\n", ret);
+        return -1;
+    }
+    ret = iot_ota_verify_update(ctx, g_data, DATA_LEN);
+    if (ret != OPRT_OK) {
+        printf("  update failed: %d\n", ret);
+        iot_ota_verify_abort(ctx);
+        return -1;
+    }
+    ret = iot_ota_verify_finish(ctx);
+    if (ret != OPRT_OK) {
+        printf("  finish returned %d, expected OPRT_OK\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_hmac_match_streamed(void)
+{
+    iot_ota_upgrade_info_t info = { .hmac = (char *)KAT_HMAC };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK) {
+        printf("  init failed: %d\n", ret);
+        return -1;
+    }
+
+    /* Feed in irregular chunks: 1, 13, 64, 128, ... remainder. */
+    size_t off = 0;
+    size_t chunk = 1;
+    while (off < DATA_LEN) {
+        if (off + chunk > DATA_LEN) chunk = DATA_LEN - off;
+        ret = iot_ota_verify_update(ctx, g_data + off, chunk);
+        if (ret != OPRT_OK) {
+            printf("  update failed at %zu: %d\n", off, ret);
+            iot_ota_verify_abort(ctx);
+            return -1;
+        }
+        off += chunk;
+        chunk = chunk >= 128 ? 13 : chunk * 2;
+    }
+
+    ret = iot_ota_verify_finish(ctx);
+    if (ret != OPRT_OK) {
+        printf("  streamed finish returned %d, expected OPRT_OK\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_hmac_mismatch(void)
+{
+    iot_ota_upgrade_info_t info = { .hmac = (char *)KAT_HMAC };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    uint8_t image[DATA_LEN];
+    memcpy(image, g_data, DATA_LEN);
+    corrupt_byte(image, 500);
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK) {
+        printf("  init failed: %d\n", ret);
+        return -1;
+    }
+    iot_ota_verify_update(ctx, image, DATA_LEN);
+    ret = iot_ota_verify_finish(ctx);
+
+    if (ret != OPRT_OTA_VERIFY_FAILED) {
+        printf("  finish returned %d, expected OPRT_OTA_VERIFY_FAILED\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_hmac_wrong_expected(void)
+{
+    /* Correct data, but the cloud hmac is for a different image. */
+    iot_ota_upgrade_info_t info = { .hmac = (char *)KAT_HMAC_BAD };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK) {
+        printf("  init failed: %d\n", ret);
+        return -1;
+    }
+    iot_ota_verify_update(ctx, g_data, DATA_LEN);
+    ret = iot_ota_verify_finish(ctx);
+    if (ret != OPRT_OTA_VERIFY_FAILED) {
+        printf("  finish returned %d, expected OPRT_OTA_VERIFY_FAILED\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_hmac_uppercase_expected(void)
+{
+    iot_ota_upgrade_info_t info = { .hmac = (char *)KAT_HMAC_UP };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK) {
+        printf("  init failed: %d\n", ret);
+        return -1;
+    }
+    iot_ota_verify_update(ctx, g_data, DATA_LEN);
+    ret = iot_ota_verify_finish(ctx);
+    if (ret != OPRT_OK) {
+        printf("  finish returned %d, expected OPRT_OK (case-insensitive)\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_md5_match_and_mismatch(void)
+{
+    iot_ota_upgrade_info_t info = { .md5 = (char *)KAT_MD5 };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK) {
+        printf("  init failed: %d\n", ret);
+        return -1;
+    }
+    iot_ota_verify_update(ctx, g_data, DATA_LEN);
+    ret = iot_ota_verify_finish(ctx);
+    if (ret != OPRT_OK) {
+        printf("  md5 finish returned %d, expected OPRT_OK\n", ret);
+        return -1;
+    }
+
+    /* Mismatch: correct data, wrong expected md5. */
+    info.md5 = (char *)KAT_MD5_BAD;
+    ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK) {
+        printf("  init (bad) failed: %d\n", ret);
+        return -1;
+    }
+    iot_ota_verify_update(ctx, g_data, DATA_LEN);
+    ret = iot_ota_verify_finish(ctx);
+    if (ret != OPRT_OTA_VERIFY_FAILED) {
+        printf("  md5 finish returned %d, expected OPRT_OTA_VERIFY_FAILED\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_no_digest_unsupported(void)
+{
+    iot_ota_upgrade_info_t info = {0};
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_NOT_SUPPORTED) {
+        printf("  init returned %d, expected OPRT_NOT_SUPPORTED\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+/* An empty hmac means the cloud configured none: fall through to the md5. */
+static int test_empty_hmac_falls_back_to_md5(void)
+{
+    iot_ota_upgrade_info_t info = { .hmac = (char *)"", .md5 = (char *)KAT_MD5 };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK || ctx == NULL) {
+        printf("  init returned %d, expected OPRT_OK via md5\n", ret);
+        return -1;
+    }
+    iot_ota_verify_update(ctx, g_data, DATA_LEN);
+    ret = iot_ota_verify_finish(ctx);
+    if (ret != OPRT_OK) {
+        printf("  finish returned %d, expected OPRT_OK\n", ret);
+        return -1;
+    }
+
+    /* Both digests empty is the same as neither being present. */
+    info.md5 = (char *)"";
+    ctx = NULL;
+    ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_NOT_SUPPORTED) {
+        printf("  empty md5+hmac returned %d, expected OPRT_NOT_SUPPORTED\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+/* A non-empty hmac that is malformed must fail, never silently downgrade to
+ * the weaker md5 the cloud also sent. */
+static int test_malformed_hmac_never_downgrades(void)
+{
+    iot_ota_upgrade_info_t info = { .hmac = (char *)"deadbeef",
+                                    .md5  = (char *)KAT_MD5 };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret == OPRT_OK) {
+        printf("  malformed hmac was downgraded to md5\n");
+        iot_ota_verify_abort(ctx);
+        return -1;
+    }
+    if (ret != OPRT_INVALID_PARAMETER) {
+        printf("  returned %d, expected OPRT_INVALID_PARAMETER\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_bad_length_rejected(void)
+{
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    /* hmac too short */
+    iot_ota_upgrade_info_t info = { .hmac = (char *)KAT_MD5 };  /* 32 chars, not 64 */
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_INVALID_PARAMETER) {
+        printf("  short hmac returned %d, expected OPRT_INVALID_PARAMETER\n", ret);
+        return -1;
+    }
+
+    /* md5 too long */
+    info.hmac = NULL;
+    info.md5 = (char *)KAT_HMAC;  /* 64 chars, not 32 */
+    ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_INVALID_PARAMETER) {
+        printf("  long md5 returned %d, expected OPRT_INVALID_PARAMETER\n", ret);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_null_params(void)
+{
+    iot_ota_upgrade_info_t info = { .hmac = (char *)KAT_HMAC };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    if (iot_ota_verify_init(NULL, &info, &ctx) != OPRT_INVALID_PARAMETER ||
+        iot_ota_verify_init(&g_client, NULL, &ctx) != OPRT_INVALID_PARAMETER ||
+        iot_ota_verify_init(&g_client, &info, NULL) != OPRT_INVALID_PARAMETER) {
+        printf("  init NULL guards failed\n");
+        return -1;
+    }
+    if (iot_ota_verify_update(NULL, g_data, DATA_LEN) != OPRT_INVALID_PARAMETER) {
+        printf("  update NULL guard failed\n");
+        return -1;
+    }
+    if (iot_ota_verify_finish(NULL) != OPRT_INVALID_PARAMETER) {
+        printf("  finish NULL guard failed\n");
+        return -1;
+    }
+    iot_ota_verify_abort(NULL);  /* must be a safe no-op */
+    return 0;
+}
+
+static int test_abort_after_partial(void)
+{
+    iot_ota_upgrade_info_t info = { .hmac = (char *)KAT_HMAC };
+    iot_ota_verify_ctx_t *ctx = NULL;
+
+    int ret = iot_ota_verify_init(&g_client, &info, &ctx);
+    if (ret != OPRT_OK) {
+        printf("  init failed: %d\n", ret);
+        return -1;
+    }
+    iot_ota_verify_update(ctx, g_data, 100);
+    iot_ota_verify_abort(ctx);  /* must free without crashing (leaks-checked) */
+    return 0;
+}
+
+int main(void)
+{
+    printf("========== OTA Verify Test Suite ==========\n");
+
+    g_client.pal = get_default_pal();
+    strcpy(g_client.secret_key, TEST_KEY);
+    test_setup();
+
+    RUN_TEST(test_hmac_match_single_update);
+    RUN_TEST(test_hmac_match_streamed);
+    RUN_TEST(test_hmac_mismatch);
+    RUN_TEST(test_hmac_wrong_expected);
+    RUN_TEST(test_hmac_uppercase_expected);
+    RUN_TEST(test_md5_match_and_mismatch);
+    RUN_TEST(test_no_digest_unsupported);
+    RUN_TEST(test_empty_hmac_falls_back_to_md5);
+    RUN_TEST(test_malformed_hmac_never_downgrades);
+    RUN_TEST(test_bad_length_rejected);
+    RUN_TEST(test_null_params);
+    RUN_TEST(test_abort_after_partial);
+
+    printf("\n========== Results: %d/%d passed ==========\n", tests_passed, tests_run);
+    return tests_passed == tests_run ? 0 : 1;
+}

--- a/modules/iot-client/test/mock/atop_mock.py
+++ b/modules/iot-client/test/mock/atop_mock.py
@@ -399,8 +399,8 @@ def handle_upgrade_get(request_data, config):
                 "cdnUrl": "https://images.example.com/firmware/v2.0.0.bin",
                 "httpsUrl": "https://fireware.example.com:1443/firmware/v2.0.0.bin",
                 "size": "1024000",
-                "md5": "aabbccdd11223344",
-                "hmac": "eeff00112233445566778899aabbccdd"
+                "md5": "aabbccdd11223344aabbccdd11223344",
+                "hmac": "eeff00112233445566778899aabbccddeeff00112233445566778899aabbccdd"
             }
 
         response = {


### PR DESCRIPTION
Add streaming verifier API (iot_ota_verify_init/update/finish/abort) that validates downloaded OTA firmware against the cloud-provided md5/hmac digest. The cloud already returns these fields via iot_ota_check_upgrade(), but nothing validated the downloaded bytes against them.

Algorithm matches TuyaOpen's tuya_ota.c: when hmac is present, the expected value is HMAC-SHA256(device secret_key,
UPPERCASE_hex(SHA-256(image))) — the HMAC message is the 64-char uppercase hex string of the SHA-256 digest (matching TuyaOpen's hex2str). When only md5 is present, falls back to plain MD5. Comparison is case-insensitive with constant-time hex compare.

New error code OPRT_OTA_VERIFY_FAILED (-0x000D) — skips -0x0008..-0x000C already used by iot_dp.h. Both OTA demos (ESP-IDF + POSIX) now verify the digest before completing the upgrade. Unit tests with Python-generated known-answer vectors cover match/mismatch/streaming/edge cases.

Verified end-to-end against a real Tuya cloud OTA task (firmware v2.2.8, 3254320 bytes): hmac(sec_key, SHA-256_hex_UPPER) matches the cloud value.