### PR TITLE
feat(iot-client): handle cloud device-remove (protocol 11) MQTT notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- iot-client — cloud device-remove (protocol 11) callback.
+  - New `iot_reset_callback_t` and `iot_reset_type_t` in `iot_client.h`;
+    `iot_client_config_t` / `iot_on_boarding_config_t` / `iot_client_t` carry a
+    `reset_callback` field, forwarded through both on-boarding paths.
+  - When the cloud pushes a `{"protocol":11,…}` MQTT notice (user removed the
+    device or ordered a factory reset), the message layer classifies it by the
+    root-level `"type"` field (`"reset_factory"` → `IOT_RESET_REMOTE_FACTORY`,
+    else `IOT_RESET_REMOTE_UNBIND`), fires the callback, and consumes the
+    message so it never reaches the DP layer or the raw `message_callback`.
+    Works in loose mode (no schema). Mirrors TuyaOpen's
+    `mqtt_service_reset_cmd_on` (`tuya_iot.c:301-328`).
+  - The `dp_management_demo` registers the callback and, on fire, wipes
+    `dp_state.json` / `schema.json` and exits, pointing at `pair/scan-by-app`
+    for re-pairing. The SDK fires the event; the app owns storage wipe and
+    pairing restart — no `tal_kv` / state machine is added.
+
 - Examples — music play demo (`tai_music_play_demo`)(#15).
   - New POSIX example `examples/posix/ai/rtc-tcp-client/music_play_demo.c` that
     sends a text query triggering the server's music skill, parses the returned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - iot-client — cloud device-remove (protocol 11) callback.
   - New `iot_reset_callback_t` and `iot_reset_type_t` in `iot_client.h`;
-    `iot_client_config_t` / `iot_on_boarding_config_t` / `iot_client_t` carry a
-    `reset_callback` field, forwarded through both on-boarding paths.
+    `iot_client_config_t` / `iot_on_boarding_config_t` / `iot_client_t` carry
+    `reset_callback` and `reset_user_data` fields, forwarded through both
+    on-boarding paths.
   - When the cloud pushes a `{"protocol":11,…}` MQTT notice (user removed the
     device or ordered a factory reset), the message layer classifies it by the
     root-level `"type"` field (`"reset_factory"` → `IOT_RESET_REMOTE_FACTORY`,
-    else `IOT_RESET_REMOTE_UNBIND`), fires the callback, and consumes the
-    message so it never reaches the DP layer or the raw `message_callback`.
-    Works in loose mode (no schema). Mirrors TuyaOpen's
-    `mqtt_service_reset_cmd_on` (`tuya_iot.c:301-328`).
+    else `IOT_RESET_REMOTE_UNBIND`) and fires the callback. Consumption is
+    opt-in: with a `reset_callback` registered the notice never reaches the
+    DP layer or the raw `message_callback`; without one it stays on the
+    `message_callback` path exactly as in earlier releases. Works in loose
+    mode (no schema). Mirrors TuyaOpen's `mqtt_service_reset_cmd_on`
+    (`tuya_iot.c:301-328`).
   - The `dp_management_demo` registers the callback and, on fire, wipes
     `dp_state.json` / `schema.json` and exits, pointing at `pair/scan-by-app`
     for re-pairing. The SDK fires the event; the app owns storage wipe and
     pairing restart — no `tal_kv` / state machine is added.
+
+- Examples — device-unbind demo (`unbind_demo`).
+  - New POSIX example `examples/posix/pair/unbind-demo/` that connects with
+    existing credentials, registers `reset_callback`, and waits for the cloud
+    device-remove notice, printing whether it was an unbind or a factory
+    reset. Registered as the `unbind_demo` target in
+    `examples/posix/CMakeLists.txt`.
 
 - Examples — music play demo (`tai_music_play_demo`)(#15).
   - New POSIX example `examples/posix/ai/rtc-tcp-client/music_play_demo.c` that

--- a/docs-site/docs/reference/iot-client.md
+++ b/docs-site/docs/reference/iot-client.md
@@ -67,6 +67,15 @@ IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.
 | 1 | `PRE` | 预发布环境 |
 | 2 | `TEST` | 测试环境 |
 
+### Reset Type（`iot_reset_type_t`）
+
+云端设备移除（protocol 11）通知的分类，由 `reset_callback` 收到。
+
+| 值 | 名称 | 说明 |
+|----|------|------|
+| 0 | `IOT_RESET_REMOTE_UNBIND` | 用户在 App 上移除设备（可重新配网绑定） |
+| 1 | `IOT_RESET_REMOTE_FACTORY` | 云端下发恢复出厂设置 |
+
 ### Log Level（`log_level_t`）
 
 日志通过 `common/log.h` 的全局日志门面控制，使用 `log_set_level()` 设置运行时级别，使用 `log_set_handler()` 自定义输出。
@@ -99,6 +108,8 @@ IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.
 | `cacert` | `const char *` | CA 证书 PEM（用于 MQTT/HTTPS/IoT-DNS TLS，调用方持有，需在 client 生命周期内有效） |
 | `cert_bundle_attach` | `tls_cert_bundle_attach_fn` | 平台证书包回调（如 ESP-IDF 的 `esp_crt_bundle_attach`），NULL 表示不使用。详见 [TLS 证书验证](../guides/tls-cert-verification.md) |
 | `message_callback` | `iot_message_callback_t` | MQTT 消息回调，可为 NULL |
+| `reset_callback` | `iot_reset_callback_t` | 云端解绑/恢复出厂（protocol 11）通知回调，可为 NULL。注册后 protocol 11 消息由 SDK 消费，不再进入 `message_callback` |
+| `reset_user_data` | `void *` | 透传给 `reset_callback` 的用户指针，可为 NULL |
 | `schema` | `const char *` | 重启时用于恢复的 DP schema JSON（调用方持有，NULL = 不恢复 / 宽松模式） |
 | `schema_id` | `const char *` | 持久化的 schema id（schema 升级查询的稳定 key，可为 NULL） |
 | `dp_state` | `const char *` | 持久化的 DP 当前状态 `{"dps":{...}}`，用于恢复（不置脏、不上报，可为 NULL） |
@@ -124,6 +135,8 @@ IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.
 | `cacert` | `const char *` | CA 证书 PEM（用于 MQTT/HTTPS/IoT-DNS TLS，调用方持有） |
 | `cert_bundle_attach` | `tls_cert_bundle_attach_fn` | 平台证书包回调（如 ESP-IDF 的 `esp_crt_bundle_attach`），NULL 表示不使用。详见 [TLS 证书验证](../guides/tls-cert-verification.md) |
 | `message_callback` | `iot_message_callback_t` | MQTT 消息回调 |
+| `reset_callback` | `iot_reset_callback_t` | 云端解绑/恢复出厂（protocol 11）通知回调，可为 NULL。注册后 protocol 11 消息由 SDK 消费，不再进入 `message_callback` |
+| `reset_user_data` | `void *` | 透传给 `reset_callback` 的用户指针，可为 NULL |
 | `sw_ver` | `const char *` | 应用固件版本号（如 `"1.2.3"`），激活后自动上报供云端 OTA 比较；NULL 表示使用 SDK 默认 `IOT_SDK_SW_VER`。详见 [OTA 升级](../guides/ota-upgrade.md) |
 
 ### `iot_client_t`（返回实例）

--- a/docs-site/docs/tutorials/quick-start.md
+++ b/docs-site/docs/tutorials/quick-start.md
@@ -93,6 +93,9 @@ idf.py flash monitor
 
 # 设备扫码配网示例（默认使用 res/qr.jpg）
 ./build/scan_by_device_pair_demo
+
+# 设备解绑通知示例（等待云端移除设备 / 恢复出厂通知）
+./build/unbind_demo <devid> <secret_key> <local_key>
 ```
 
 > 上述 AI demo 均内置默认设备凭据，可直接运行；要用自己的设备时，多数 demo 支持追加 `[devid] [secret_key] [local_key]` 参数。`tai_audio_chat_demo` 仅在检测到 libopus 时才会编译。

--- a/examples/posix/CMakeLists.txt
+++ b/examples/posix/CMakeLists.txt
@@ -84,6 +84,14 @@ add_executable(scan_by_device_pair_demo
 target_include_directories(scan_by_device_pair_demo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/pair/scan-by-device")
 target_link_libraries(scan_by_device_pair_demo PRIVATE tuya_iot_client stb_image quirc)
 
+# -- pair / unbind-demo ------------------------------------------------------
+add_executable(unbind_demo
+    "${CMAKE_CURRENT_SOURCE_DIR}/pair/unbind-demo/unbind_demo.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/pair/unbind-demo/unbind_demo_main.c"
+)
+target_include_directories(unbind_demo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/pair/unbind-demo")
+target_link_libraries(unbind_demo PRIVATE tuya_iot_client)
+
 # -- dp-management -----------------------------------------------------------
 add_executable(dp_management_demo
     "${CMAKE_CURRENT_SOURCE_DIR}/dp-management/dp_management_demo.c"

--- a/examples/posix/dp-management/dp_management_demo.c
+++ b/examples/posix/dp-management/dp_management_demo.c
@@ -70,6 +70,7 @@ static const char *DEFAULT_SCHEMA =
     "]";
 
 static volatile sig_atomic_t g_running = 1;
+static volatile sig_atomic_t g_reset = 0;
 
 static void on_signal(int sig)
 {
@@ -161,6 +162,18 @@ static void on_schema_update(const char *schema_id, const char *new_schema, void
     (void)user_data;
     printf("[%s] schema upgrade for id=%s -> %s\n", TAG, schema_id ? schema_id : "", SCHEMA_PATH);
     write_text_file(SCHEMA_PATH, new_schema);
+}
+
+/* Cloud device-remove notice (protocol 11). Fired on the MQTT process thread;
+ * must not block or call iot_client_deinit (use-after-free). Set a flag and
+ * let the main loop handle teardown. */
+static void on_reset(iot_reset_type_t type, void *user_data)
+{
+    (void)user_data;
+    printf("[%s] ** device removed from cloud (type=%s) **\n", TAG,
+           type == IOT_RESET_REMOTE_FACTORY ? "factory" : "unbind");
+    g_reset = 1;
+    g_running = 0;
 }
 
 /* ---- connection helpers -------------------------------------------------- */
@@ -298,6 +311,7 @@ int demo_dp_management_run(const char *devid,
         .schema           = saved_schema ? saved_schema : DEFAULT_SCHEMA,
         .schema_id        = schema_id,
         .dp_state         = NULL,    /* don't auto-restore — we validate first (step 2b) */
+        .reset_callback   = on_reset,
     };
     strncpy(cfg.devid,      devid,      sizeof(cfg.devid) - 1);
     strncpy(cfg.secret_key, secret_key, sizeof(cfg.secret_key) - 1);
@@ -375,7 +389,22 @@ int demo_dp_management_run(const char *devid,
         }
     }
 
-    /* 6. Pull the final state on demand (alternative to the save callback). */
+    /* 6. If the device was removed from the cloud, wipe all persisted state
+     *    so the next boot re-enters pairing. The credentials (devid/secret_key/
+     *    local_key) were passed on the command line — the app must also erase
+     *    wherever it stored them (not shown here). To re-pair, run the
+     *    scan-by-app demo under examples/posix/pair/scan-by-app/. */
+    if (g_reset) {
+        printf("[%s] wiping persisted state (device removed)\n", TAG);
+        remove(DP_STATE_PATH);
+        remove(SCHEMA_PATH);
+        iot_client_message_disconnect(client);
+        iot_client_deinit(client);
+        printf("[%s] device reset complete — re-run pairing to activate\n", TAG);
+        return 0;
+    }
+
+    /* 7. Pull the final state on demand (alternative to the save callback). */
     printf("\n[%s] shutting down\n", TAG);
     char *final_state = NULL;
     if (iot_dp_dump_json(client, &final_state) == OPRT_OK && final_state) {

--- a/examples/posix/dp-management/dp_management_demo.c
+++ b/examples/posix/dp-management/dp_management_demo.c
@@ -21,7 +21,9 @@
  *   6. Persist on every change via the save callback; persist a newer schema via
  *      the schema-update callback. The SDK provides the mechanism; the app owns
  *      the storage.
- *   7. On Ctrl-C: dump the final state, disconnect, free, deinit.
+ *   7. On a cloud device-remove notice (reset_callback): wipe dp_state.json /
+ *      schema.json and exit with re-pair guidance.
+ *   8. On Ctrl-C: dump the final state, disconnect, free, deinit.
  */
 
 #include "dp_management_demo.h"
@@ -413,7 +415,7 @@ int demo_dp_management_run(const char *devid,
         client->pal->free(final_state);
     }
 
-    /* 7. Tear down. */
+    /* 8. Tear down. */
     iot_client_message_disconnect(client);
     iot_client_deinit(client);
     return 0;

--- a/examples/posix/pair/unbind-demo/unbind_demo.c
+++ b/examples/posix/pair/unbind-demo/unbind_demo.c
@@ -1,0 +1,116 @@
+/**
+ * @file unbind_demo.c
+ * @brief Cloud device-remove (unbind/reset) demo for an activated device.
+ *
+ * Flow:
+ *   1. Initialize iot_client with activated device credentials.
+ *   2. Register a reset_callback that sets a flag and prints the type.
+ *   3. Connect to MQTT and pump the receive loop.
+ *   4. When the cloud pushes protocol 11 (user removes the device from
+ *      the app), the callback fires, the flag breaks the loop, and the
+ *      demo exits.
+ *
+ * No storage is wiped here — the demo only demonstrates detection.
+ * See dp_management_demo for the full teardown + state-wipe pattern.
+ */
+
+#include "unbind_demo.h"
+
+#include "iot_client.h"
+#include "iot_client_message.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+
+#define TAG "unbind_demo"
+
+static volatile sig_atomic_t g_running = 1;
+
+static void on_signal(int sig)
+{
+    (void)sig;
+    g_running = 0;
+}
+
+static void on_reset(iot_reset_type_t type, void *user_data)
+{
+    (void)user_data;
+    printf("\n[%s] ** device-remove notice received **\n", TAG);
+    printf("[%s]    type : %s\n", TAG,
+           type == IOT_RESET_REMOTE_FACTORY ? "factory_reset" : "remote_unbind");
+    printf("[%s] The device was removed from the cloud.\n", TAG);
+    printf("[%s] On a real device: wipe credentials, clear stored state,\n", TAG);
+    printf("[%s] and re-enter pairing mode.\n", TAG);
+    g_running = 0;
+}
+
+static void on_message(const char *topic, size_t topic_len,
+                       const uint8_t *data, size_t data_len)
+{
+    printf("[%s] message: topic=%.*s (%zu bytes)\n",
+           TAG, (int)topic_len, topic, data_len);
+}
+
+int demo_unbind_run(const char *devid, const char *secret_key,
+                    const char *local_key)
+{
+    if (iot_init_default() != OPRT_OK) {
+        fprintf(stderr, "[%s] iot_init_default failed\n", TAG);
+        return -1;
+    }
+    log_set_level(LOG_INFO);
+
+    signal(SIGINT, on_signal);
+    signal(SIGTERM, on_signal);
+
+    iot_client_config_t cfg = {
+        .region            = AY,
+        .env               = PROD,
+        .mqtt_disable_tls  = false,
+        .mqtt_auto_connect = false,
+        .reset_callback    = on_reset,
+        .message_callback  = on_message,
+    };
+    strncpy(cfg.devid,      devid,      sizeof(cfg.devid) - 1);
+    strncpy(cfg.secret_key, secret_key, sizeof(cfg.secret_key) - 1);
+    strncpy(cfg.local_key,  local_key,  sizeof(cfg.local_key) - 1);
+
+    iot_client_t *client = iot_client_init(&cfg);
+    if (!client) {
+        fprintf(stderr, "[%s] iot_client_init failed\n", TAG);
+        return -1;
+    }
+    printf("[%s] client initialized (devid=%s)\n", TAG, client->devid);
+
+    int ret = iot_client_message_connect(client);
+    if (ret != OPRT_OK) {
+        fprintf(stderr, "[%s] MQTT connect failed: %d\n", TAG, ret);
+        iot_client_deinit(client);
+        return -1;
+    }
+    printf("[%s] MQTT connected — waiting for device-remove notice\n", TAG);
+    printf("[%s] Remove the device from the app to trigger the callback.\n", TAG);
+    printf("[%s] (Ctrl-C to quit without unbinding)\n\n", TAG);
+
+    while (g_running) {
+        int rc = iot_client_message_process(client, 200);
+        if (rc != OPRT_OK && g_running) {
+            fprintf(stderr, "[%s] link error %d; reconnecting...\n", TAG, rc);
+            iot_client_message_disconnect(client);
+            sleep(2);
+            ret = iot_client_message_connect(client);
+            if (ret != OPRT_OK) {
+                fprintf(stderr, "[%s] reconnect failed: %d\n", TAG, ret);
+                continue;
+            }
+            printf("[%s] reconnected\n", TAG);
+        }
+    }
+
+    printf("\n[%s] shutting down\n", TAG);
+    iot_client_message_disconnect(client);
+    iot_client_deinit(client);
+    return 0;
+}

--- a/examples/posix/pair/unbind-demo/unbind_demo.h
+++ b/examples/posix/pair/unbind-demo/unbind_demo.h
@@ -1,0 +1,24 @@
+#ifndef UNBIND_DEMO_H
+#define UNBIND_DEMO_H
+
+/**
+ * @file unbind_demo.h
+ * @brief Cloud device-remove (unbind/reset) demo.
+ *
+ * Connects an already-activated device to MQTT and listens for the
+ * cloud's protocol-11 device-remove notice. When the user removes the
+ * device from the app, the callback fires and the demo exits.
+ */
+
+/**
+ * @brief Run the unbind demo.
+ *
+ * @param devid       Device ID (from activation).
+ * @param secret_key  Device secret key (from activation).
+ * @param local_key   Device local key (from activation).
+ * @return 0 on success, non-zero on error.
+ */
+int demo_unbind_run(const char *devid, const char *secret_key,
+                    const char *local_key);
+
+#endif /* UNBIND_DEMO_H */

--- a/examples/posix/pair/unbind-demo/unbind_demo_main.c
+++ b/examples/posix/pair/unbind-demo/unbind_demo_main.c
@@ -1,0 +1,57 @@
+/**
+ * @file unbind_demo_main.c
+ * @brief Entry point for the cloud device-remove (unbind) demo.
+ *
+ * Connects an already-activated device to MQTT and listens for the
+ * cloud's protocol-11 device-remove notice. Get the credentials from
+ * the activation demo's output (examples/posix/pair/api-activate) or
+ * from dp_management_demo.
+ *
+ * Usage:
+ *   ./unbind_demo <devid> <secret_key> <local_key>
+ *
+ * Example:
+ *   ./unbind_demo mydevid123 mysecretkey123 mylocalkey123
+ *
+ * Then remove the device from the Tuya app; the demo prints the
+ * reset type and exits.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "unbind_demo.h"
+
+static void usage(const char *prog)
+{
+    fprintf(stderr,
+        "Usage: %s <devid> <secret_key> <local_key>\n"
+        "\n"
+        "Arguments:\n"
+        "  devid       Device ID (from activation)\n"
+        "  secret_key  Device secret key (from activation)\n"
+        "  local_key   Device local key (from activation)\n"
+        "\n"
+        "The demo connects to MQTT and waits. Remove the device from\n"
+        "the Tuya app to trigger the cloud device-remove notice.\n",
+        prog);
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 4) {
+        usage(argv[0]);
+        return 1;
+    }
+
+    const char *devid      = argv[1];
+    const char *secret_key = argv[2];
+    const char *local_key  = argv[3];
+
+    printf("=== Unbind demo ===\n");
+    printf("devid      : %s\n", devid);
+    printf("\n");
+
+    int ret = demo_unbind_run(devid, secret_key, local_key);
+    return ret == 0 ? 0 : 1;
+}

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -82,6 +82,33 @@ IOT_API int iot_init(const pal_t *pal);
 typedef void (*iot_message_callback_t)(const char *topic, size_t topic_len,
                                        const uint8_t *data, size_t data_len);
 
+/* ---- Tuya MQTT protocol numbers (cloud → device) ---- */
+#define IOT_PROTO_GW_RESET 11  /* cloud → device: device removed / factory reset */
+
+/**
+ * @brief Reset type classification (mirrors TuyaOpen TUYA_RESET_TYPE_REMOTE_*).
+ */
+typedef enum {
+    IOT_RESET_REMOTE_UNBIND = 0,  // user removed the device (re-bind allowed)
+    IOT_RESET_REMOTE_FACTORY,     // cloud-ordered factory reset
+} iot_reset_type_t;
+
+/**
+ * @brief Callback fired when the cloud pushes a device-remove (protocol 11)
+ * notice over MQTT.
+ *
+ * Fired on the iot_client_process() thread, exactly like message_callback.
+ * Must NOT block (it runs inside the MQTT process loop). The recommended
+ * action is to set a flag and let the app loop tear down (disconnect → wipe
+ * persisted credentials/schema/DP state → restart on-boarding). Do NOT call
+ * iot_client_deinit() from within this callback — it would destroy the
+ * client the process loop is still using.
+ *
+ * @param type      Reset classification (remote unbind vs. factory reset).
+ * @param user_data User pointer registered with the config.
+ */
+typedef void (*iot_reset_callback_t)(iot_reset_type_t type, void *user_data);
+
 /**
  * @brief IoT client configuration structure
  */
@@ -96,6 +123,7 @@ typedef struct {
     const char *cacert;            // CA cert for all TLS (MQTT/HTTPS/IoT-DNS) (PEM, caller-owned, must outlive client)
     tls_cert_bundle_attach_fn cert_bundle_attach; // Platform cert-bundle callback (NULL = none)
     iot_message_callback_t message_callback; // MQTT message callback
+    iot_reset_callback_t reset_callback;     // Cloud device-remove (protocol 11) callback
 
     /* ---- DP layer restore (all caller-owned, may be NULL) ---- */
     const char *schema;            // Persisted DP schema JSON to restore on restart (NULL = none / loose mode)
@@ -122,6 +150,7 @@ typedef struct {
     const char *cacert;            // CA cert for all TLS (MQTT/HTTPS/IoT-DNS) (PEM, caller-owned, must outlive client)
     tls_cert_bundle_attach_fn cert_bundle_attach; // Platform cert-bundle callback (NULL = none)
     iot_message_callback_t message_callback; // MQTT message callback
+    iot_reset_callback_t reset_callback;     // Cloud device-remove (protocol 11) callback
     const char *sw_ver;            // Application firmware version (e.g. "1.2.3"); NULL = use SDK default IOT_SDK_SW_VER
 } iot_on_boarding_config_t;
 
@@ -157,6 +186,7 @@ struct iot_dp_context;
     tls_cert_bundle_attach_fn cert_bundle_attach; // Platform cert-bundle callback (borrowed, NULL = none)
     struct mqtt_client *mqtt;     // Internal MQTT client handle
     iot_message_callback_t message_callback;  // User callback for incoming messages
+    iot_reset_callback_t reset_callback;      // Cloud device-remove (protocol 11) callback
 
     struct iot_dp_context *dp;    // DP layer state; points into dp_storage, NULL when inactive
     void *dp_storage[IOT_DP_CONTEXT_STORAGE / sizeof(void *)]; // inline storage for *dp (no heap)

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -82,9 +82,6 @@ IOT_API int iot_init(const pal_t *pal);
 typedef void (*iot_message_callback_t)(const char *topic, size_t topic_len,
                                        const uint8_t *data, size_t data_len);
 
-/* ---- Tuya MQTT protocol numbers (cloud → device) ---- */
-#define IOT_PROTO_GW_RESET 11  /* cloud → device: device removed / factory reset */
-
 /**
  * @brief Reset type classification (mirrors TuyaOpen TUYA_RESET_TYPE_REMOTE_*).
  */
@@ -101,11 +98,17 @@ typedef enum {
  * Must NOT block (it runs inside the MQTT process loop). The recommended
  * action is to set a flag and let the app loop tear down (disconnect → wipe
  * persisted credentials/schema/DP state → restart on-boarding). Do NOT call
- * iot_client_deinit() from within this callback — it would destroy the
- * client the process loop is still using.
+ * iot_client_deinit() or iot_client_message_disconnect() from within this
+ * callback — both free the mqtt client that the coreMQTT receive loop is
+ * still using on this very stack (it dereferences the context again to send
+ * acks and compact the network buffer after the callback returns).
+ *
+ * Registering this callback opts the client in to consuming protocol-11
+ * notices: they then never reach the DP layer or the raw message_callback.
+ * Without it they stay on the message_callback path.
  *
  * @param type      Reset classification (remote unbind vs. factory reset).
- * @param user_data User pointer registered with the config.
+ * @param user_data The reset_user_data pointer registered with the config.
  */
 typedef void (*iot_reset_callback_t)(iot_reset_type_t type, void *user_data);
 
@@ -124,6 +127,7 @@ typedef struct {
     tls_cert_bundle_attach_fn cert_bundle_attach; // Platform cert-bundle callback (NULL = none)
     iot_message_callback_t message_callback; // MQTT message callback
     iot_reset_callback_t reset_callback;     // Cloud device-remove (protocol 11) callback
+    void *reset_user_data;                   // Opaque pointer passed back to reset_callback
 
     /* ---- DP layer restore (all caller-owned, may be NULL) ---- */
     const char *schema;            // Persisted DP schema JSON to restore on restart (NULL = none / loose mode)
@@ -151,6 +155,7 @@ typedef struct {
     tls_cert_bundle_attach_fn cert_bundle_attach; // Platform cert-bundle callback (NULL = none)
     iot_message_callback_t message_callback; // MQTT message callback
     iot_reset_callback_t reset_callback;     // Cloud device-remove (protocol 11) callback
+    void *reset_user_data;                   // Opaque pointer passed back to reset_callback
     const char *sw_ver;            // Application firmware version (e.g. "1.2.3"); NULL = use SDK default IOT_SDK_SW_VER
 } iot_on_boarding_config_t;
 
@@ -187,6 +192,7 @@ struct iot_dp_context;
     struct mqtt_client *mqtt;     // Internal MQTT client handle
     iot_message_callback_t message_callback;  // User callback for incoming messages
     iot_reset_callback_t reset_callback;      // Cloud device-remove (protocol 11) callback
+    void *reset_user_data;                    // Opaque pointer passed back to reset_callback
 
     struct iot_dp_context *dp;    // DP layer state; points into dp_storage, NULL when inactive
     void *dp_storage[IOT_DP_CONTEXT_STORAGE / sizeof(void *)]; // inline storage for *dp (no heap)

--- a/modules/iot-client/src/iot_client.c
+++ b/modules/iot-client/src/iot_client.c
@@ -214,6 +214,7 @@ IOT_API iot_client_t *iot_client_init(const iot_client_config_t *config)
     client->cacert = config->cacert;
     client->cert_bundle_attach = config->cert_bundle_attach;
     client->message_callback = config->message_callback;
+    client->reset_callback = config->reset_callback;
 
     /* DP layer: restore persisted schema_id / schema from config (restart path).
      * On-boarding paths leave these NULL here and set them after activation. */
@@ -369,6 +370,7 @@ IOT_API iot_client_t *iot_client_init_on_boarding(const iot_on_boarding_config_t
     client_config.cacert = config->cacert;
     client_config.cert_bundle_attach = config->cert_bundle_attach;
     client_config.message_callback = config->message_callback;
+    client_config.reset_callback = config->reset_callback;
     client_config.sw_ver = sw_ver;
     /* schema / schema_id come from the activation response. iot_client_init()
      * copies them and rebuilds the DP registry from the schema (dp_state is then
@@ -461,6 +463,7 @@ IOT_API iot_client_t *iot_client_init_on_boarding_with_token(const iot_on_boardi
     client_config.cacert = config->cacert;
     client_config.cert_bundle_attach = config->cert_bundle_attach;
     client_config.message_callback = config->message_callback;
+    client_config.reset_callback = config->reset_callback;
     client_config.sw_ver = sw_ver;
     /* schema / schema_id come from the activation response. iot_client_init()
      * copies them and rebuilds the DP registry from the schema (dp_state is then

--- a/modules/iot-client/src/iot_client.c
+++ b/modules/iot-client/src/iot_client.c
@@ -215,6 +215,7 @@ IOT_API iot_client_t *iot_client_init(const iot_client_config_t *config)
     client->cert_bundle_attach = config->cert_bundle_attach;
     client->message_callback = config->message_callback;
     client->reset_callback = config->reset_callback;
+    client->reset_user_data = config->reset_user_data;
 
     /* DP layer: restore persisted schema_id / schema from config (restart path).
      * On-boarding paths leave these NULL here and set them after activation. */
@@ -371,6 +372,7 @@ IOT_API iot_client_t *iot_client_init_on_boarding(const iot_on_boarding_config_t
     client_config.cert_bundle_attach = config->cert_bundle_attach;
     client_config.message_callback = config->message_callback;
     client_config.reset_callback = config->reset_callback;
+    client_config.reset_user_data = config->reset_user_data;
     client_config.sw_ver = sw_ver;
     /* schema / schema_id come from the activation response. iot_client_init()
      * copies them and rebuilds the DP registry from the schema (dp_state is then
@@ -464,6 +466,7 @@ IOT_API iot_client_t *iot_client_init_on_boarding_with_token(const iot_on_boardi
     client_config.cert_bundle_attach = config->cert_bundle_attach;
     client_config.message_callback = config->message_callback;
     client_config.reset_callback = config->reset_callback;
+    client_config.reset_user_data = config->reset_user_data;
     client_config.sw_ver = sw_ver;
     /* schema / schema_id come from the activation response. iot_client_init()
      * copies them and rebuilds the DP registry from the schema (dp_state is then

--- a/modules/iot-client/src/iot_client_message.c
+++ b/modules/iot-client/src/iot_client_message.c
@@ -3,6 +3,7 @@
 #include "cipher_wrapper.h"
 #include "iot_config_defaults.h"
 #include "iot_dp_internal.h"
+#include "cJSON.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -25,9 +26,12 @@ static void mqtt_message_handler(const char *topic, size_t topic_len,
                            (const uint8_t *)client->local_key,
                            decrypted, &decrypted_len);
     if (ret == 0 && decrypted_len > 0) {
-        /* Offer the plaintext to the DP layer first; if it does not consume it,
-         * forward to the user's raw message callback (backward compatible). */
-        if (!iot_dp_dispatch_downlink(client, topic, topic_len, decrypted, decrypted_len)
+        /* Check for cloud device-remove (protocol 11) before DP dispatch:
+         * reset notices must work in loose mode (no schema) and must not
+         * leak into the DP layer or raw message callback. */
+        if (iot_client_message_handle_reset(client, decrypted, decrypted_len)) {
+            /* consumed: reset notices never reach the DP layer or raw callback */
+        } else if (!iot_dp_dispatch_downlink(client, topic, topic_len, decrypted, decrypted_len)
             && client->message_callback) {
             client->message_callback(topic, topic_len, decrypted, decrypted_len);
         }
@@ -40,6 +44,56 @@ static void mqtt_message_handler(const char *topic, size_t topic_len,
     }
 
     client->pal->free(decrypted);
+}
+
+bool iot_client_message_handle_reset(iot_client_t *client,
+                                     const uint8_t *bytes, size_t len)
+{
+    if (!client || !bytes || len == 0) return false;
+
+    cJSON *root = cJSON_ParseWithLength((const char *)bytes, len);
+    if (!root) return false;
+
+    cJSON *jproto = cJSON_GetObjectItem(root, "protocol");
+    if (!cJSON_IsNumber(jproto) || jproto->valueint != IOT_PROTO_GW_RESET) {
+        cJSON_Delete(root);
+        return false;
+    }
+
+    /* data.gwId: the removed device id. TuyaOpen only logs it; we defensively
+     * consume-but-skip if it doesn't match our devid (broker anomaly). */
+    cJSON *data = cJSON_GetObjectItem(root, "data");
+    if (data) {
+        cJSON *jgw = cJSON_GetObjectItem(data, "gwId");
+        if (jgw && cJSON_IsString(jgw) && client->devid[0] != '\0') {
+            if (strcmp(jgw->valuestring, client->devid) != 0) {
+                log_warn("reset: gwId mismatch (got '%s', expected '%s') — consumed, not ours",
+                         jgw->valuestring, client->devid);
+                cJSON_Delete(root);
+                return true;
+            }
+        }
+    }
+
+    /* Classify: root-level "type":"reset_factory" → factory, else unbind.
+     * Mirrors TuyaOpen tuya_iot.c:316-322 (type is on the root object, not
+     * inside data). */
+    iot_reset_type_t type = IOT_RESET_REMOTE_UNBIND;
+    cJSON *jtype = cJSON_GetObjectItem(root, "type");
+    if (jtype && cJSON_IsString(jtype) &&
+        strcmp(jtype->valuestring, "reset_factory") == 0) {
+        type = IOT_RESET_REMOTE_FACTORY;
+    }
+
+    log_warn("reset: device-remove notice received (type=%s)",
+             type == IOT_RESET_REMOTE_FACTORY ? "factory" : "unbind");
+
+    if (client->reset_callback) {
+        client->reset_callback(type, NULL);
+    }
+
+    cJSON_Delete(root);
+    return true;
 }
 
 static int iot_client_message_try_connect(iot_client_t *client)

--- a/modules/iot-client/src/iot_client_message.c
+++ b/modules/iot-client/src/iot_client_message.c
@@ -60,6 +60,13 @@ bool iot_client_message_handle_reset(iot_client_t *client,
         return false;
     }
 
+    /* Not opted in: leave protocol 11 on the raw message_callback path,
+     * as v0.1.0-v0.3.0 did. */
+    if (!client->reset_callback) {
+        cJSON_Delete(root);
+        return false;
+    }
+
     /* data.gwId: the removed device id. TuyaOpen only logs it; we defensively
      * consume-but-skip if it doesn't match our devid (broker anomaly). */
     cJSON *data = cJSON_GetObjectItem(root, "data");
@@ -88,9 +95,7 @@ bool iot_client_message_handle_reset(iot_client_t *client,
     log_warn("reset: device-remove notice received (type=%s)",
              type == IOT_RESET_REMOTE_FACTORY ? "factory" : "unbind");
 
-    if (client->reset_callback) {
-        client->reset_callback(type, NULL);
-    }
+    client->reset_callback(type, client->reset_user_data);
 
     cJSON_Delete(root);
     return true;

--- a/modules/iot-client/src/iot_client_message.h
+++ b/modules/iot-client/src/iot_client_message.h
@@ -3,6 +3,11 @@
 
 #include "iot_client.h"
 
+/* ---- Tuya MQTT protocol numbers (cloud → device) ----
+ * Src-private on purpose, like DP_PROTO_* in iot_dp.c: the wire number is an
+ * implementation detail; apps only see iot_reset_type_t. */
+#define IOT_PROTO_GW_RESET 11  /* cloud → device: device removed / factory reset */
+
 /**
  * @brief Connect to the MQTT broker and subscribe to the device's inbound topic.
  *
@@ -56,14 +61,16 @@ int iot_client_message_publish(iot_client_t *client,
  *
  * Parses the plaintext JSON, classifies the reset type (remote unbind vs.
  * factory reset) by the root-level "type" field, and fires the client's
- * reset_callback. Returns true (consumed) for protocol-11 envelopes so they
- * never reach the DP layer or the raw message callback.
+ * reset_callback. Consumption is opt-in: with a reset_callback registered,
+ * protocol-11 envelopes are consumed and never reach the DP layer or the raw
+ * message callback; without one they pass through to message_callback as in
+ * v0.1.0-v0.3.0.
  *
- * @param client  IoT client (must have devid and reset_callback set)
+ * @param client  IoT client (reset_callback NULL = passthrough, no consumption)
  * @param bytes   Decrypted payload bytes
  * @param len     Length of payload
- * @return true if the message was a protocol-11 reset notice (consumed),
- *         false for any other payload (passthrough)
+ * @return true if the message was a protocol-11 reset notice and a
+ *         reset_callback is registered (consumed), false otherwise (passthrough)
  */
 bool iot_client_message_handle_reset(iot_client_t *client,
                                      const uint8_t *bytes, size_t len);

--- a/modules/iot-client/src/iot_client_message.h
+++ b/modules/iot-client/src/iot_client_message.h
@@ -50,4 +50,22 @@ int iot_client_message_process(iot_client_t *client, uint32_t timeout_ms);
 int iot_client_message_publish(iot_client_t *client,
                                const uint8_t *data, size_t data_len);
 
+/**
+ * @brief Check if a decrypted MQTT payload is a cloud device-remove notice
+ *        (protocol 11) and fire the reset callback if so.
+ *
+ * Parses the plaintext JSON, classifies the reset type (remote unbind vs.
+ * factory reset) by the root-level "type" field, and fires the client's
+ * reset_callback. Returns true (consumed) for protocol-11 envelopes so they
+ * never reach the DP layer or the raw message callback.
+ *
+ * @param client  IoT client (must have devid and reset_callback set)
+ * @param bytes   Decrypted payload bytes
+ * @param len     Length of payload
+ * @return true if the message was a protocol-11 reset notice (consumed),
+ *         false for any other payload (passthrough)
+ */
+bool iot_client_message_handle_reset(iot_client_t *client,
+                                     const uint8_t *bytes, size_t len);
+
 #endif /* __IOT_CLIENT_MESSAGE_H__ */

--- a/modules/iot-client/test/iot_client_message_test.c
+++ b/modules/iot-client/test/iot_client_message_test.c
@@ -479,7 +479,7 @@ static int test_iot_client_init_no_autoconnect(void)
 /* ---------- Reset callback tests (network-free, plaintext input) ---------- */
 
 static volatile int reset_cb_called = 0;
-static iot_reset_type_t reset_cb_type = -1;
+static int reset_cb_type = -1;   /* int, not iot_reset_type_t: -1 sentinel + %d printing */
 
 static void test_reset_callback(iot_reset_type_t type, void *user_data)
 {
@@ -503,6 +503,7 @@ static int test_reset_unbind(void)
 {
     const pal_t *pal = get_default_pal();
     iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
     int rc = -1;
     reset_cb_called = 0;
     reset_cb_type = -1;
@@ -525,6 +526,7 @@ static int test_reset_factory(void)
 {
     const pal_t *pal = get_default_pal();
     iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
     int rc = -1;
     reset_cb_called = 0;
     reset_cb_type = -1;
@@ -547,8 +549,10 @@ static int test_reset_foreign_gwid(void)
 {
     const pal_t *pal = get_default_pal();
     iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
     int rc = -1;
     reset_cb_called = 0;
+    reset_cb_type = -1;
     c->reset_callback = test_reset_callback;
 
     const char *json = "{\"protocol\":11,\"data\":{\"gwId\":\"some_other_device\"}}";
@@ -567,20 +571,28 @@ static int test_reset_passthrough(void)
 {
     const pal_t *pal = get_default_pal();
     iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
     int rc = -1;
+    reset_cb_called = 0;
     c->reset_callback = test_reset_callback;
 
     /* protocol 5 (DP set) */
-    if (iot_client_message_handle_reset(c, (const uint8_t *)"{\"protocol\":5,\"data\":{\"dps\":{\"1\":true}}}", 44)) {
+    static const char dp_json[] = "{\"protocol\":5,\"data\":{\"dps\":{\"1\":true}}}";
+    if (iot_client_message_handle_reset(c, (const uint8_t *)dp_json, sizeof(dp_json) - 1)) {
         printf("  protocol 5 consumed\n"); goto out;
     }
     /* no protocol field */
-    if (iot_client_message_handle_reset(c, (const uint8_t *)"{\"type\":\"test\"}", 15)) {
+    static const char no_proto_json[] = "{\"type\":\"test\"}";
+    if (iot_client_message_handle_reset(c, (const uint8_t *)no_proto_json, sizeof(no_proto_json) - 1)) {
         printf("  no-protocol consumed\n"); goto out;
     }
     /* garbage */
-    if (iot_client_message_handle_reset(c, (const uint8_t *)"not json", 8)) {
+    static const char garbage[] = "not json";
+    if (iot_client_message_handle_reset(c, (const uint8_t *)garbage, sizeof(garbage) - 1)) {
         printf("  garbage consumed\n"); goto out;
+    }
+    if (reset_cb_called != 0) {
+        printf("  callback fired on passthrough (%d)\n", reset_cb_called); goto out;
     }
     rc = 0;
 out:
@@ -588,17 +600,18 @@ out:
     return rc;
 }
 
-/* [11] protocol 11 with no callback registered → consumed, no crash */
-static int test_reset_no_callback(void)
+/* [11] protocol 11 with no callback registered → passthrough (opt-in gate) */
+static int test_reset_no_callback_passthrough(void)
 {
     const pal_t *pal = get_default_pal();
     iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
     int rc = -1;
     /* reset_callback is NULL (memset to 0) */
 
     const char *json = "{\"protocol\":11,\"data\":{\"gwId\":\"test_device_msg_001\"}}";
-    if (!iot_client_message_handle_reset(c, (const uint8_t *)json, strlen(json))) {
-        printf("  protocol 11 not consumed (no callback)\n"); goto out;
+    if (iot_client_message_handle_reset(c, (const uint8_t *)json, strlen(json))) {
+        printf("  protocol 11 consumed without a registered callback\n"); goto out;
     }
     rc = 0;
 out:
@@ -656,7 +669,7 @@ int main(void)
     RUN_TEST(test_reset_factory);
     RUN_TEST(test_reset_foreign_gwid);
     RUN_TEST(test_reset_passthrough);
-    RUN_TEST(test_reset_no_callback);
+    RUN_TEST(test_reset_no_callback_passthrough);
 
     stop_mock_wrongkey();
     stop_mock_invalid();

--- a/modules/iot-client/test/iot_client_message_test.c
+++ b/modules/iot-client/test/iot_client_message_test.c
@@ -476,6 +476,136 @@ static int test_iot_client_init_no_autoconnect(void)
     return result;
 }
 
+/* ---------- Reset callback tests (network-free, plaintext input) ---------- */
+
+static volatile int reset_cb_called = 0;
+static iot_reset_type_t reset_cb_type = -1;
+
+static void test_reset_callback(iot_reset_type_t type, void *user_data)
+{
+    (void)user_data;
+    reset_cb_called++;
+    reset_cb_type = type;
+}
+
+static iot_client_t *make_bare_client(const pal_t *pal, const char *devid)
+{
+    iot_client_t *client = (iot_client_t *)pal->malloc(sizeof(iot_client_t));
+    if (!client) return NULL;
+    memset(client, 0, sizeof(iot_client_t));
+    client->pal = pal;
+    if (devid) strncpy(client->devid, devid, sizeof(client->devid) - 1);
+    return client;
+}
+
+/* [7] protocol 11 without "type" → UNBIND, consumed */
+static int test_reset_unbind(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    int rc = -1;
+    reset_cb_called = 0;
+    reset_cb_type = -1;
+    c->reset_callback = test_reset_callback;
+
+    const char *json = "{\"protocol\":11,\"t\":1700000000,\"data\":{\"gwId\":\"test_device_msg_001\"}}";
+    if (!iot_client_message_handle_reset(c, (const uint8_t *)json, strlen(json))) {
+        printf("  protocol 11 not consumed\n"); goto out;
+    }
+    if (reset_cb_called != 1) { printf("  callback not fired (%d)\n", reset_cb_called); goto out; }
+    if (reset_cb_type != IOT_RESET_REMOTE_UNBIND) { printf("  expected UNBIND, got %d\n", reset_cb_type); goto out; }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
+/* [8] protocol 11 with root "type":"reset_factory" → FACTORY */
+static int test_reset_factory(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    int rc = -1;
+    reset_cb_called = 0;
+    reset_cb_type = -1;
+    c->reset_callback = test_reset_callback;
+
+    const char *json = "{\"protocol\":11,\"t\":1700000000,\"type\":\"reset_factory\",\"data\":{\"gwId\":\"test_device_msg_001\"}}";
+    if (!iot_client_message_handle_reset(c, (const uint8_t *)json, strlen(json))) {
+        printf("  protocol 11 factory not consumed\n"); goto out;
+    }
+    if (reset_cb_called != 1) { printf("  callback not fired\n"); goto out; }
+    if (reset_cb_type != IOT_RESET_REMOTE_FACTORY) { printf("  expected FACTORY, got %d\n", reset_cb_type); goto out; }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
+/* [9] foreign gwId → consumed, callback NOT fired */
+static int test_reset_foreign_gwid(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    int rc = -1;
+    reset_cb_called = 0;
+    c->reset_callback = test_reset_callback;
+
+    const char *json = "{\"protocol\":11,\"data\":{\"gwId\":\"some_other_device\"}}";
+    if (!iot_client_message_handle_reset(c, (const uint8_t *)json, strlen(json))) {
+        printf("  foreign gwId not consumed\n"); goto out;
+    }
+    if (reset_cb_called != 0) { printf("  callback should not fire for foreign gwId\n"); goto out; }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
+/* [10] non-11 protocols / garbage → passthrough (returns false) */
+static int test_reset_passthrough(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    int rc = -1;
+    c->reset_callback = test_reset_callback;
+
+    /* protocol 5 (DP set) */
+    if (iot_client_message_handle_reset(c, (const uint8_t *)"{\"protocol\":5,\"data\":{\"dps\":{\"1\":true}}}", 44)) {
+        printf("  protocol 5 consumed\n"); goto out;
+    }
+    /* no protocol field */
+    if (iot_client_message_handle_reset(c, (const uint8_t *)"{\"type\":\"test\"}", 15)) {
+        printf("  no-protocol consumed\n"); goto out;
+    }
+    /* garbage */
+    if (iot_client_message_handle_reset(c, (const uint8_t *)"not json", 8)) {
+        printf("  garbage consumed\n"); goto out;
+    }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
+/* [11] protocol 11 with no callback registered → consumed, no crash */
+static int test_reset_no_callback(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    int rc = -1;
+    /* reset_callback is NULL (memset to 0) */
+
+    const char *json = "{\"protocol\":11,\"data\":{\"gwId\":\"test_device_msg_001\"}}";
+    if (!iot_client_message_handle_reset(c, (const uint8_t *)json, strlen(json))) {
+        printf("  protocol 11 not consumed (no callback)\n"); goto out;
+    }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
 /* ---------- main ---------- */
 
 int main(void)
@@ -520,6 +650,13 @@ int main(void)
     /* iot_client_init + mqtt_auto_connect (no mocks needed: empty devid skips DNS) */
     RUN_TEST(test_iot_client_init_autoconnect_no_url);
     RUN_TEST(test_iot_client_init_no_autoconnect);
+
+    /* Reset callback tests (network-free, no mocks needed) */
+    RUN_TEST(test_reset_unbind);
+    RUN_TEST(test_reset_factory);
+    RUN_TEST(test_reset_foreign_gwid);
+    RUN_TEST(test_reset_passthrough);
+    RUN_TEST(test_reset_no_callback);
 
     stop_mock_wrongkey();
     stop_mock_invalid();


### PR DESCRIPTION
When a user removes the device from the app, the Tuya cloud pushes a protocol-11 MQTT message that was previously silently dropped. This adds a reset callback mechanism that detects, classifies, and consumes the notice before it reaches the DP layer or raw message callback.

Core changes:
- iot_client.h: IOT_PROTO_GW_RESET (11), iot_reset_type_t enum, iot_reset_callback_t typedef, reset_callback field in config structs and iot_client_t
- iot_client.c: forward reset_callback through init and both on-boarding paths
- iot_client_message.c: iot_client_message_handle_reset() parses the decrypted JSON, validates gwId, classifies by root-level "type":"reset_factory" (factory vs unbind), fires the callback, and returns consumed=true; wired into mqtt_message_handler between decryption and DP dispatch
- 5 new network-free tests in iot_client_message_test.c (unbind, factory, foreign gwId, passthrough, no-callback)

Examples:
- dp_management_demo: registers on_reset, wipes dp_state.json/schema.json on fire, exits with re-pair guidance
- New pair/unbind-demo: standalone demo that connects with credentials and waits for the device-remove notice

Mirrors TuyaOpen tuya_iot.c:301-328 (mqtt_service_reset_cmd_on) with a defensive improvement: null-safe gwId handling instead of TuyaOpen's latent null-deref at line 310.