### PR TITLE
Feat/atop generic call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- iot-client — generic ATOP call (`iot_atop_call`), for cloud interfaces the SDK
+  does not wrap by name.
+  - New public header `iot_atop.h`: pass an `api` name, its `version` and a JSON
+    request body; get the envelope's `result` back as a JSON string, plus the
+    cloud's `errorCode` / `errorMsg` and server time. Signing, AES-GCM body
+    encryption, TLS, host resolution and envelope parsing stay inside the SDK,
+    so the caller never handles the device secret key.
+  - Credentials and endpoint come from `iot_client_t` (same pattern as
+    `iot_ota.c`), so the call covers activated devices only — it signs with
+    `devid` + `secret_key` and returns `OPRT_UNINITIALIZED` before activation.
+    Activation itself uses `uuid` + `authkey` and stays behind
+    `iot_client_init_on_boarding()`.
+  - `result` is returned as a JSON string rather than a `cJSON *`, keeping cJSON
+    out of the public ABI and the memory ownership on one side
+    (`iot_atop_response_free`). Request bodies are forwarded verbatim — callers
+    supply whatever the interface needs, including the `t` field most ATOP
+    interfaces expect in the body — and are validated only as far as "parses as
+    a JSON object", to turn a typo into a local error instead of a round trip.
+  - New guide `docs-site/docs/guides/atop-generic-call.md` lists the existing
+    named wrappers (so they are not reimplemented) and the three criteria for
+    promoting an interface to a named wrapper: used by more than one product,
+    non-trivial protocol semantics, or needs SDK-internal state.
+  - `modules/iot-client/CONTEXT.md` gains the ATOP vocabulary it was missing —
+    *ATOP interface*, *envelope*, *named wrapper*, *generic call* — and flags
+    "封装/wrap" as the ambiguity that made the design discussion circle.
+
 - iot-client — cloud device-remove (protocol 11) callback.
   - New `iot_reset_callback_t` and `iot_reset_type_t` in `iot_client.h`;
     `iot_client_config_t` / `iot_on_boarding_config_t` / `iot_client_t` carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- iot-client — a cloud-rejected ATOP call reported success. When the envelope
+  carried `success: false`, `atop_response_result_parse_cjson()` logged
+  `errorCode` / `errorMsg` and dropped them, then returned `OPRT_OK` for every
+  code except `GATEWAY_NOT_EXISTS`. Callers had to inspect
+  `atop_base_response_t.success` separately, and only three of the eight named
+  wrappers did.
+  - Worst case was `tuya.device.schema.newest.get`: a rejection came back as
+    `OPRT_OK` with `result == NULL`, which `atop_schema_newest_get()` reports as
+    "no newer schema" — a permission error and an up-to-date schema were
+    indistinguishable from the return value.
+  - The envelope now copies both strings into new `error_code` / `error_msg`
+    fields on `atop_base_response_t` and returns the new
+    `OPRT_ATOP_BUSINESS_ERROR (-0x000E)` for every rejection uniformly —
+    including `GATEWAY_NOT_EXISTS`, whose historical `OPRT_COMMUNICATION_ERROR`
+    mapping protected no caller (nothing in the repo branches on it) while
+    presenting a permanent "device removed" verdict as a retryable transport
+    failure. A caller that needs per-code policy branches on `error_code`.
+  - Behavioral note: named wrappers now return `-0x000E` instead of the old
+    `OPRT_OK`-with-empty-result (or, for two wrappers, an internal
+    `OPRT_COMMUNICATION_ERROR` mapping) when the cloud rejects a call. The
+    activation error log names the new code; the two now-unreachable
+    `.success` re-checks in `atop.c` were removed.
+  - `atop_base_response_free()` is now NULL-safe and frees `result` whenever it
+    is set instead of gating on `.success`, which only ever added a way to leak.
+    A rejection whose envelope lacks `errorCode` still logs the server's
+    `errorMsg` (previously that text was dropped on this path).
+
 - iot-client — US-East (`UEAZ`) and West-Europe (`WEAZ`) never resolved an MQTT
   broker(#15). `iot_region_to_string()` sent the enum name as the `region` field
   of `POST /v2/url_config`, but the service knows those two by their two-letter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ set(IOT_CLIENT_SOURCES
     "${IOT_CLIENT_DIR}/src/atop_base.c"
     "${IOT_CLIENT_DIR}/src/cipher_wrapper.c"
     "${IOT_CLIENT_DIR}/src/http_client_interface.c"
+    "${IOT_CLIENT_DIR}/src/iot_atop.c"
     "${IOT_CLIENT_DIR}/src/iot_client.c"
     "${IOT_CLIENT_DIR}/src/iot_client_message.c"
     "${IOT_CLIENT_DIR}/src/iot_dns.c"
@@ -287,6 +288,7 @@ if(AGENTIC_KIT_BUILD_TESTS AND AGENTIC_KIT_ENABLE_PROJECT_TESTS)
     agentic_kit_add_iot_test(iot_cipher_test "${IOT_CLIENT_TESTS_DIR}/cipher_test.c")
     agentic_kit_add_iot_test(iot_dns_test "${IOT_CLIENT_TESTS_DIR}/dns_test.c")
     agentic_kit_add_iot_test(iot_atop_test "${IOT_CLIENT_TESTS_DIR}/atop_test.c")
+    agentic_kit_add_iot_test(iot_atop_call_test "${IOT_CLIENT_TESTS_DIR}/iot_atop_call_test.c")
     agentic_kit_add_iot_test(iot_mqtt_test "${IOT_CLIENT_TESTS_DIR}/mqtt_test.c")
     agentic_kit_add_iot_test(iot_message_test "${IOT_CLIENT_TESTS_DIR}/iot_client_message_test.c")
     agentic_kit_add_iot_test(iot_on_boarding_test "${IOT_CLIENT_TESTS_DIR}/on_boarding_test.c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 set(AGENTIC_KIT_ENABLE_PROJECT_TESTS ${AGENTIC_KIT_BUILD_TESTS})
 set(BUILD_TESTING OFF CACHE BOOL "Disable third-party tests" FORCE)
+# include(CTest) only calls enable_testing() while BUILD_TESTING is ON, and the cache
+# is forced OFF above — so re-configures would silently stop regenerating the ctest
+# list. Enable it explicitly for our own tests.
+if(AGENTIC_KIT_BUILD_TESTS)
+    enable_testing()
+endif()
 set(ENABLE_TESTING OFF CACHE BOOL "Disable mbedTLS tests" FORCE)
 set(ENABLE_PROGRAMS OFF CACHE BOOL "Disable mbedTLS programs" FORCE)
 set(ENABLE_TESTING OFF CACHE BOOL "Disable cJSON tests" FORCE)

--- a/docs-site/docs/guides/atop-generic-call.md
+++ b/docs-site/docs/guides/atop-generic-call.md
@@ -1,0 +1,117 @@
+---
+title: 调用未封装的云端接口（ATOP 通用入口）
+sidebar_label: ATOP 通用调用
+sidebar_position: 8
+---
+
+# 调用未封装的云端接口
+
+设备与涂鸦云之间的 HTTP 接口统称 **ATOP 接口**，由 `api` 名和 `version` 两个字段唯一确定，例如 `tuya.device.upgrade.get` v4.4。
+
+SDK 为其中一部分接口提供了**具名接口**（`iot_ota_*`、`iot_dp_*` 等），返回类型化的结构体。云端可调的 ATOP 接口远多于此，为了不让业务被 SDK 的排期卡住，SDK 提供一个**通用入口** `iot_atop_call()`：你给出 `api`、`version` 和 JSON 请求体，拿回 `result` 字段的 JSON 字符串。
+
+签名、请求体 AES-GCM 加密、TLS、host 解析、信封解析都在 SDK 内部完成，**设备密钥不会离开 SDK**。
+
+## 先确认有没有具名接口
+
+已经封装好的接口不要用通用入口重新实现——它们额外处理了云端返回的各种变体，并且有单测覆盖：
+
+| ATOP api | version | 具名接口 |
+| --- | --- | --- |
+| `tuya.device.upgrade.get` | 4.4 | `iot_ota_check_upgrade()` |
+| `tuya.device.versions.update` | 4.1 | `iot_ota_report_version()` |
+| `tuya.device.upgrade.status.update` | 4.1 | `iot_ota_report_status()` |
+| `tuya.device.schema.newest.get` | 1.0 | DP 层内部自动查询 |
+| `thing.ai.agent.token.get` | 1.0 | `iot_client_get_session_token()` |
+| `tuya.device.qrcode.info.get` | 1.1 | `iot_get_qrcode_info()` |
+| `thing.device.opensdk.active` | 2.0 | `iot_client_init_on_boarding()` |
+| `tuya.device.meta.save` | 1.0 | 激活流程内部调用 |
+
+## 什么时候该要一个具名接口
+
+通用入口是逃生通道，不是首选。满足下面**任意一条**时，这个接口值得进 SDK 变成具名接口，欢迎提 issue：
+
+- **多产品复用** —— 两个以上产品线都要调。否则等于把单个产品的业务逻辑塞进 SDK。
+- **协议语义不平凡** —— 有状态机、多步时序，或者云端返回形态需要宽容解析。这类知识重复实现必然出偏差。
+- **需要参与 SDK 内部状态** —— 要改 `iot_client_t` 的字段或触发 SDK 回调。业务层拿不到内部状态，物理上只能在 SDK 里做。
+
+三条都不满足的接口，留在业务层用通用入口调是合适的终态，不是技术债。
+
+## API
+
+```c
+#include "iot_atop.h"
+
+typedef struct {
+    const char *api;      /* 例 "tuya.device.upgrade.get"，必填 */
+    const char *version;  /* 例 "4.4"，必填 */
+    const char *data;     /* 请求体，JSON 对象字符串；NULL 或 "" 视为 "{}" */
+} iot_atop_request_t;
+
+typedef struct {
+    char *result;            /* result 字段的 JSON 字符串；云端没返回则为 NULL */
+    char  error_code[48];    /* 云端 errorCode；成功时为 "" */
+    char  error_msg[128];    /* 云端 errorMsg；成功时为 "" */
+    int32_t server_time;     /* 信封里的服务器时间 t */
+} iot_atop_response_t;
+
+int  iot_atop_call(iot_client_t *client,
+                   const iot_atop_request_t *request,
+                   iot_atop_response_t *response);
+void iot_atop_response_free(iot_client_t *client, iot_atop_response_t *response);
+```
+
+## 示例
+
+```c
+#include "iot_atop.h"
+
+char body[192];
+snprintf(body, sizeof(body),
+         "{\"schemaId\":\"%s\",\"version\":\"\",\"t\":%u}",
+         schema_id, (unsigned)time(NULL));
+
+iot_atop_request_t  req  = { .api     = "tuya.device.schema.newest.get",
+                             .version = "1.0",
+                             .data    = body };
+iot_atop_response_t resp = {0};
+
+int rc = iot_atop_call(client, &req, &resp);
+if (rc == OPRT_OK) {
+    if (resp.result != NULL) {
+        my_parse(resp.result);          /* result 是 JSON 文本，用什么库解析都行 */
+    }
+} else if (rc == OPRT_ATOP_BUSINESS_ERROR) {
+    /* 请求到达了云端，被云端拒绝 —— error_code 说明原因 */
+    log_error("rejected: %s (%s)", resp.error_code, resp.error_msg);
+} else {
+    /* 传输层失败：DNS / TLS / HTTP / 解密 */
+    log_error("call failed: %d", rc);
+}
+
+iot_atop_response_free(client, &resp);   /* 每条路径都要调，包括失败路径 */
+```
+
+## 返回值：区分"云端拒绝"和"没连上"
+
+这是使用通用入口时最重要的一点。你调的接口 SDK 并不认识，所以 SDK 无法替你判断业务是否成功，**云端自己的 errorCode 是唯一可靠的线索**：
+
+| 返回值 | 含义 | 怎么处理 |
+| --- | --- | --- |
+| `OPRT_OK` | 云端接受了这次调用 | `result` 是结果 JSON，或 NULL（云端没返回 result，这是合法的） |
+| `OPRT_ATOP_BUSINESS_ERROR` | 到达了云端，被云端拒绝 | 看 `error_code` / `error_msg`，按你的接口文档处理 |
+| `OPRT_INVALID_PARAMETER` | 参数不对，或 `data` 不是 JSON 对象 | 本地就拦下了，没发网络请求 |
+| `OPRT_UNINITIALIZED` | 设备还没有激活凭据 | 先完成激活 |
+| 其他 | 传输层失败（DNS / TLS / HTTP / 解密） | 可重试 |
+
+`error_code[0] == '\0'` 等价于"业务成功"。
+
+## 限制
+
+**只支持已激活的设备。** 通用入口用 `devid` + `secret_key` 签名。激活本身用的是 `uuid` + `authkey`，是另一条路径，仍然只能通过 `iot_client_init_on_boarding()` 走。在没有凭据的 client 上调用返回 `OPRT_UNINITIALIZED`。
+
+**请求体原样透传。** SDK 不会改写你的请求体，所以接口要求的字段必须自己带齐——**包括大多数 ATOP 接口在请求体里要求的 `t` 时间戳字段**。SDK 只校验到"能解析成 JSON 对象"为止，目的是把手误变成一个立刻返回的 `OPRT_INVALID_PARAMETER`，而不是花一次 HTTPS 往返换一句含义模糊的云端拒绝。
+
+**`result` 是字符串，不是 cJSON 对象。** 这样 cJSON 不会进入 SDK 的公共 ABI，业务层不必绑定 SDK 的 cJSON 版本，内存归属也清晰：`iot_atop_response_free()` 负责释放。
+
+**设备时钟要基本准确。** 签名带时间戳，设备时间偏差过大云端会拒签。`resp.server_time` 是云端返回的时间（秒级 Unix 时间戳），可以用来校正本地时钟。

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -54,6 +54,7 @@ const sidebars: SidebarsConfig = {
             'guides/dp-persistence',
             'guides/device-mcp',
             'guides/ota-upgrade',
+            'guides/atop-generic-call',
             'guides/tls-cert-verification',
             'guides/porting-to-new-platform',
           ],

--- a/examples/esp-idf/components/agentic_kit/CMakeLists.txt
+++ b/examples/esp-idf/components/agentic_kit/CMakeLists.txt
@@ -15,6 +15,7 @@ set(AK_SRCS
     ${AK_DIR}/modules/iot-client/src/atop_base.c
     ${AK_DIR}/modules/iot-client/src/cipher_wrapper.c
     ${AK_DIR}/modules/iot-client/src/http_client_interface.c
+    ${AK_DIR}/modules/iot-client/src/iot_atop.c
     ${AK_DIR}/modules/iot-client/src/iot_client.c
     ${AK_DIR}/modules/iot-client/src/iot_client_message.c
     ${AK_DIR}/modules/iot-client/src/iot_dns.c

--- a/modules/iot-client/CONTEXT.md
+++ b/modules/iot-client/CONTEXT.md
@@ -53,12 +53,39 @@ Replacing the device's schema with a newer version for the same Schema ID, fetch
 the application polling the cloud (there is no MQTT schema-change notification).
 _Avoid_: migration, update (too generic).
 
+**ATOP interface**:
+A named device-side HTTP service in the cloud, identified by the pair `api` name and
+`version` — e.g. `tuya.device.upgrade.get` v4.4. Nothing else distinguishes one from
+another.
+_Avoid_: interface (too generic), HTTP request (that is the transport).
+
+**Envelope**:
+The outer `{success, result, t, errorCode, errorMsg}` structure wrapping every ATOP
+response. A well-formed envelope does not mean the call succeeded: `success` is a
+separate verdict, and a rejection carries `errorCode` instead of `result`.
+_Avoid_: response, payload.
+
+**Named wrapper**:
+A typed SDK function covering one ATOP interface — it builds the request body, parses
+the result into a struct, and defines who frees what. E.g. `iot_ota_check_upgrade()`.
+_Avoid_: 封装 / wrapping (verb, ambiguous about which layer), packaging.
+
+**Generic call**:
+The public entry point (`iot_atop_call()`) that reaches any ATOP interface by `api` +
+`version`, JSON in and JSON out, with no typing. Signing and encryption still happen
+inside the SDK.
+_Avoid_: passthrough (implies unsigned, which it is not), raw call.
+
 ### Flagged ambiguities
 
 - **"state"** is overloaded: *DP state* (the values), *schema* (the definitions), and
   *connection state* (MQTT up/down) are three different things — always qualify it.
 - **"update"** is overloaded: *DP set* (cloud changes a value) vs *schema upgrade*
   (the DP definitions change). Use the specific term.
+- **"封装" / "wrap"** is overloaded when talking about cloud interfaces: adding a
+  *named wrapper* to the SDK is a different act from calling an interface through the
+  *generic call*. Say which one — "does this need a named wrapper?" is answerable,
+  "should we wrap this?" is not.
 
 ## Example dialogue
 

--- a/modules/iot-client/include/iot_atop.h
+++ b/modules/iot-client/include/iot_atop.h
@@ -1,0 +1,139 @@
+/**
+ * @file iot_atop.h
+ * @brief Generic ATOP call — reach a cloud interface the SDK does not wrap by name.
+ *
+ * The SDK wraps a handful of ATOP interfaces by name (activation, OTA, schema
+ * upgrade, AI session token …). Everything else is reachable through this one
+ * entry point: you supply the `api` name, its `version`, and the request body as
+ * a JSON string; you get the `result` field back as a JSON string.
+ *
+ * Signing, AES-GCM body encryption, TLS, host resolution and envelope parsing
+ * are all handled here — the device's secret key never leaves the SDK.
+ *
+ * ## When to use a named API instead
+ *
+ * Prefer an existing named API (`iot_ota_*`, `iot_dp_*`, …) whenever one covers
+ * what you need: they return typed structs, tolerate the cloud's response
+ * variations, and are covered by tests. Reach for `iot_atop_call()` when no
+ * named API exists — and ask for one to be added when the interface is used by
+ * more than one product, has non-trivial protocol semantics, or has to touch
+ * SDK-internal state.
+ *
+ * ## Activated devices only
+ *
+ * The call signs with the device's `devid` + `secret_key`, so it works only
+ * after activation. It returns `OPRT_UNINITIALIZED` on a client that has no
+ * credentials yet. Activation itself uses a different credential pair and stays
+ * behind `iot_client_init_on_boarding()`.
+ *
+ * ## Request bodies are passed through verbatim
+ *
+ * The body is not rewritten, so it must already carry whatever the interface
+ * requires — including the `t` timestamp field that most ATOP interfaces expect
+ * inside the body. It is validated only as far as "parses as a JSON object", to
+ * turn a typo into an immediate error instead of an HTTPS round trip.
+ *
+ * ## Example
+ *
+ * ```c
+ * char body[128];
+ * snprintf(body, sizeof(body),
+ *          "{\"schemaId\":\"%s\",\"version\":\"\",\"t\":%u}",
+ *          schema_id, (unsigned)time(NULL));
+ *
+ * iot_atop_request_t  req  = { .api = "tuya.device.schema.newest.get",
+ *                              .version = "1.0",
+ *                              .data = body };
+ * iot_atop_response_t resp = {0};
+ *
+ * int rc = iot_atop_call(client, &req, &resp);
+ * if (rc == OPRT_ATOP_BUSINESS_ERROR) {
+ *     // reached the cloud, cloud said no -- resp.error_code says why
+ *     log_error("rejected: %s (%s)", resp.error_code, resp.error_msg);
+ * } else if (rc == OPRT_OK) {
+ *     // resp.result is the "result" field as JSON, or NULL if it was null
+ *     my_parse(resp.result);
+ * }
+ * iot_atop_response_free(client, &resp);
+ * ```
+ */
+
+#ifndef __IOT_ATOP_H__
+#define __IOT_ATOP_H__
+
+#include <stdint.h>
+
+#include "iot_client.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Buffer sizes for the cloud's error strings (see iot_atop_response_t). */
+#define IOT_ATOP_ERROR_CODE_LEN  48
+#define IOT_ATOP_ERROR_MSG_LEN   128
+
+/**
+ * @brief What to call.
+ *
+ * `api` and `version` together identify an ATOP interface, exactly as they
+ * appear in the cloud's interface documentation.
+ */
+typedef struct {
+    const char *api;      /**< e.g. "tuya.device.upgrade.get" (required) */
+    const char *version;  /**< e.g. "4.4" (required) */
+    const char *data;     /**< request body, a JSON object string; NULL/"" = "{}" */
+} iot_atop_request_t;
+
+/**
+ * @brief What came back.
+ *
+ * `error_code` is the discriminator: it is `""` on success and carries the
+ * cloud's own code (e.g. "ILLEGAL_PARAM") when the call was rejected. Free with
+ * iot_atop_response_free() regardless of the return code.
+ */
+typedef struct {
+    char *result;                              /**< "result" field as JSON; NULL if the cloud sent none */
+    char  error_code[IOT_ATOP_ERROR_CODE_LEN]; /**< cloud errorCode; "" on success */
+    char  error_msg[IOT_ATOP_ERROR_MSG_LEN];   /**< cloud errorMsg;  "" on success */
+    int32_t server_time;                       /**< server time from the envelope ("t"), seconds since epoch */
+} iot_atop_response_t;
+
+/**
+ * @brief Call an ATOP interface by name.
+ *
+ * The return code separates transport from business outcome:
+ * - `OPRT_OK` — the cloud accepted the call. `response->result` holds the
+ *   result JSON, or is NULL when the cloud returned no result.
+ * - `OPRT_ATOP_BUSINESS_ERROR` — the call reached the cloud and was rejected.
+ *   `response->error_code` / `error_msg` say why.
+ * - `OPRT_INVALID_PARAMETER` — bad arguments, or `data` is not a JSON object.
+ * - `OPRT_UNINITIALIZED` — the client has no device credentials yet.
+ * - anything else — transport-level failure (DNS, TLS, HTTP, decrypt).
+ *
+ * `response` is zeroed on entry, so it is safe to pass the same struct to
+ * repeated calls as long as each is followed by iot_atop_response_free().
+ *
+ * @param[in]  client   Activated IoT client (supplies credentials + endpoint)
+ * @param[in]  request  Interface to call and the body to send
+ * @param[out] response Result and/or the cloud's error strings
+ * @return see above
+ */
+IOT_API int iot_atop_call(iot_client_t *client,
+                          const iot_atop_request_t *request,
+                          iot_atop_response_t *response);
+
+/**
+ * @brief Release an iot_atop_response_t and zero it.
+ *
+ * Safe on an all-zero struct and safe to call twice. Call it on every path,
+ * including after a failed iot_atop_call().
+ */
+IOT_API void iot_atop_response_free(iot_client_t *client,
+                                    iot_atop_response_t *response);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __IOT_ATOP_H__ */

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -28,6 +28,7 @@
 
 /* -0x0008..-0x000C are used by iot_dp.h (DP error codes) */
 #define OPRT_OTA_VERIFY_FAILED        (-0x000D) //-13, OTA firmware digest mismatch
+#define OPRT_ATOP_BUSINESS_ERROR      (-0x000E) //-14, ATOP call reached the cloud but was rejected (see errorCode)
 
 /* ---- Logging subsystem ----
  * The IoT SDK shares the process-wide log facade (see log.h).

--- a/modules/iot-client/src/atop.c
+++ b/modules/iot-client/src/atop.c
@@ -788,7 +788,7 @@ int atop_upgrade_get(const pal_t *pal, const ota_upgrade_request_t *request, ota
     cJSON *result = atop_response.result;
     if (result == NULL) {
         /* success=true but result=null → cloud has no upgrade configured for this device */
-        log_debug("atop_upgrade_get: no upgrade available (success=%d)", atop_response.success);
+        log_debug("atop_upgrade_get: no upgrade available");
         atop_base_response_free(pal, &atop_response);
         return OPRT_OK;   /* no-upgrade is success; response->has_upgrade stays false */
     }
@@ -925,13 +925,9 @@ int atop_version_update(const pal_t *pal, const ota_version_update_request_t *re
         return rt;
     }
 
-    bool success = atop_response.success;
+    /* OPRT_OK from atop_base_request() implies success == true -- a rejected
+     * envelope now returns OPRT_ATOP_BUSINESS_ERROR and is caught above. */
     atop_base_response_free(pal, &atop_response);
-
-    if (!success) {
-        log_error("atop_version_update: cloud returned failure");
-        return OPRT_COMMUNICATION_ERROR;
-    }
 
     log_debug("atop_version_update: success");
     return OPRT_OK;
@@ -993,13 +989,9 @@ int atop_upgrade_status_update(const pal_t *pal, const ota_status_update_request
         return rt;
     }
 
-    bool success = atop_response.success;
+    /* OPRT_OK from atop_base_request() implies success == true -- a rejected
+     * envelope now returns OPRT_ATOP_BUSINESS_ERROR and is caught above. */
     atop_base_response_free(pal, &atop_response);
-
-    if (!success) {
-        log_error("atop_upgrade_status_update: cloud returned failure");
-        return OPRT_COMMUNICATION_ERROR;
-    }
 
     log_debug("atop_upgrade_status_update: success (channel=%d, status=%d)",
               request->channel, (int)request->status);

--- a/modules/iot-client/src/atop_base.c
+++ b/modules/iot-client/src/atop_base.c
@@ -399,27 +399,42 @@ static int atop_response_result_parse_cjson(const uint8_t *input, size_t ilen, a
          return OPRT_OK;
      }
 
-     // Exception parse
-     char *errorCode = NULL;
+     /* Exception parse. The cloud reached a verdict, so the envelope itself is
+      * well-formed -- but the call failed. Copy errorCode/errorMsg out before
+      * releasing the JSON so the caller can act on them, and return a real
+      * error: returning OPRT_OK here would make a rejection indistinguishable
+      * from an empty-but-successful result (e.g. "no newer schema"). */
+     const cJSON *error_code_item = cJSON_GetObjectItem(root, "errorCode");
+     const cJSON *error_msg_item  = cJSON_GetObjectItem(root, "errorMsg");
+
      response->success = false;
      response->result = NULL;
 
-     // error msg dump
-     if (cJSON_GetObjectItem(root, "errorMsg")) {
-         log_error("errorMsg:%s", cJSON_GetObjectItem(root, "errorMsg")->valuestring);
+     if (cJSON_IsString(error_msg_item) && error_msg_item->valuestring != NULL) {
+         snprintf(response->error_msg, sizeof(response->error_msg), "%s",
+                  error_msg_item->valuestring);
      }
 
-     if (cJSON_GetObjectItem(root, "errorCode") == NULL) {
-         log_error("not found json errorCode key");
+     if (!cJSON_IsString(error_code_item) || error_code_item->valuestring == NULL) {
+         /* Keep the server's explanation in the log even on this malformed
+          * path -- it is often the only clue (e.g. a signature-time-skew
+          * message from a gateway that omits errorCode). */
+         log_error("atop rejected without errorCode (errorMsg=%s)",
+                   response->error_msg);
          cJSON_Delete(root);
          return OPRT_COMMUNICATION_ERROR;
      }
 
-     errorCode = cJSON_GetObjectItem(root, "errorCode")->valuestring;
+     snprintf(response->error_code, sizeof(response->error_code), "%s",
+              error_code_item->valuestring);
+     log_error("atop rejected: errorCode=%s errorMsg=%s",
+               response->error_code, response->error_msg);
 
-     if (strcasecmp(errorCode, "GATEWAY_NOT_EXISTS") == 0) {
-         rt = OPRT_COMMUNICATION_ERROR;
-     }
+     /* Every rejection is the same verdict: the cloud answered and said no.
+      * No special-casing of individual errorCodes here (GATEWAY_NOT_EXISTS
+      * included) -- error_code is carried on the response precisely so that
+      * per-code policy can live in the caller that knows the interface. */
+     rt = OPRT_ATOP_BUSINESS_ERROR;
 
      // free cJSON object
      cJSON_Delete(root);
@@ -629,7 +644,15 @@ static int atop_response_result_parse_cjson(const uint8_t *input, size_t ilen, a
    */
   void atop_base_response_free(const pal_t *pal, atop_base_response_t *response)
   {
-      if (response->success == true && response->result) {
+      (void)pal;
+      if (response == NULL) {
+          return;
+      }
+      /* Not gated on .success: the parse path only ever attaches a result on
+       * success, so keying the free off the flag adds a way to leak without
+       * adding any safety. */
+      if (response->result != NULL) {
           cJSON_Delete(response->result);
+          response->result = NULL;
       }
   }

--- a/modules/iot-client/src/atop_base.h
+++ b/modules/iot-client/src/atop_base.h
@@ -44,6 +44,12 @@
      tls_cert_bundle_attach_fn cert_bundle_attach; // Platform cert-bundle callback
  } atop_base_request_t;
 
+ /* Envelope error strings are copied out of the response before the parsed JSON
+  * is released, so callers can act on the cloud's verdict without re-parsing.
+  * Fixed-size to keep the struct allocation-free. */
+ #define ATOP_ERROR_CODE_LEN  48
+ #define ATOP_ERROR_MSG_LEN   128
+
  typedef struct {
      bool success;
      cJSON *result;
@@ -51,6 +57,8 @@
      void *user_data;
      uint8_t *raw_data;
      size_t raw_data_len;
+     char error_code[ATOP_ERROR_CODE_LEN];  /* cloud errorCode; "" when success */
+     char error_msg[ATOP_ERROR_MSG_LEN];    /* cloud errorMsg;  "" when success */
  } atop_base_response_t;
 
  /**
@@ -59,6 +67,13 @@
   * This function sends a request to the atop base service using the provided
   * request data. The response data will be stored in the provided response
   * structure.
+  *
+  * A well-formed envelope carrying success=false is NOT OPRT_OK: it returns
+  * OPRT_ATOP_BUSINESS_ERROR with .error_code / .error_msg filled in, for every
+  * errorCode uniformly. Callers therefore never need to inspect .success
+  * themselves; a caller that must treat a specific code differently (e.g.
+  * GATEWAY_NOT_EXISTS meaning "device removed, re-pair") branches on
+  * .error_code.
   *
   * @param request Pointer to the `atop_base_request_t` structure containing the
   * request data.

--- a/modules/iot-client/src/iot_atop.c
+++ b/modules/iot-client/src/iot_atop.c
@@ -1,0 +1,159 @@
+/**
+ * @file iot_atop.c
+ * @brief Public generic ATOP call — thin, deliberately untyped layer over
+ *        atop_base_request().
+ *
+ * Everything hard (URL signing, AES-GCM body encryption, TLS, envelope parsing)
+ * already lives in atop_base.c. This file exists to make that capability a
+ * supported public API rather than a reachable internal one: it sources the
+ * credentials and endpoint from iot_client_t so the caller never handles the
+ * secret key, and it converts the internal cJSON result into a plain JSON
+ * string so cJSON stays out of the public ABI.
+ *
+ * Follows the same host-resolution pattern as iot_ota.c.
+ */
+
+#include "iot_atop.h"
+
+#include "atop_base.h"
+#include "cJSON.h"
+#include "iot_config_defaults.h"   /* IOT_DEFAULT_PORT */
+#include "iot_dp_internal.h"       /* iot_client_resolve_atop_host */
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+/* The public buffers mirror the internal envelope buffers. Static-assert rather
+ * than re-deriving one from the other, so a future widening of either side
+ * fails the build instead of silently truncating the cloud's error code. */
+_Static_assert(IOT_ATOP_ERROR_CODE_LEN >= ATOP_ERROR_CODE_LEN,
+               "public error_code buffer must not truncate the envelope's");
+_Static_assert(IOT_ATOP_ERROR_MSG_LEN >= ATOP_ERROR_MSG_LEN,
+               "public error_msg buffer must not truncate the envelope's");
+
+/* A generic call forwards the caller's body untouched, so the only thing worth
+ * checking locally is that it is a JSON object at all. Catching a typo here
+ * saves an HTTPS round trip, and the cloud's rejection reason for malformed
+ * input is far less specific than "your JSON does not parse". */
+static int atop_body_is_json_object(const char *data)
+{
+    /* require_null_terminated: plain cJSON_Parse() stops at the first complete
+     * value and would wave through "{}garbage" -- exactly the snprintf-slip
+     * class this check exists to catch locally. */
+    cJSON *root = cJSON_ParseWithOpts(data, NULL, 1);
+    if (root == NULL) {
+        return OPRT_INVALID_PARAMETER;
+    }
+    bool is_object = cJSON_IsObject(root);
+    cJSON_Delete(root);
+    return is_object ? OPRT_OK : OPRT_INVALID_PARAMETER;
+}
+
+int iot_atop_call(iot_client_t *client,
+                  const iot_atop_request_t *request,
+                  iot_atop_response_t *response)
+{
+    if (response == NULL) {
+        return OPRT_INVALID_PARAMETER;
+    }
+    /* Zero before any other validation: the header promises "zeroed on entry"
+     * and that iot_atop_response_free() is safe on every path -- an early
+     * return that skipped this would hand back stale (or stack-garbage)
+     * error_code/result for the caller to act on or free. */
+    memset(response, 0, sizeof(*response));
+
+    if (client == NULL || client->pal == NULL || request == NULL) {
+        return OPRT_INVALID_PARAMETER;
+    }
+    if (request->api == NULL || request->api[0] == '\0' ||
+        request->version == NULL || request->version[0] == '\0') {
+        log_error("iot_atop_call: api and version are required");
+        return OPRT_INVALID_PARAMETER;
+    }
+
+    /* Activated devices only: this path signs with devid + secret_key.
+     * Activation uses uuid + authkey and stays behind on-boarding. */
+    if (client->devid[0] == '\0' || client->secret_key[0] == '\0') {
+        log_error("iot_atop_call: client has no device credentials yet");
+        return OPRT_UNINITIALIZED;
+    }
+
+    const char *body = (request->data != NULL && request->data[0] != '\0')
+                           ? request->data
+                           : "{}";
+    int rt = atop_body_is_json_object(body);
+    if (rt != OPRT_OK) {
+        log_error("iot_atop_call: data is not a JSON object");
+        return rt;
+    }
+
+    char host[64] = {0};
+    uint16_t port = IOT_DEFAULT_PORT;
+    iot_client_resolve_atop_host(client, host, sizeof(host), &port);
+
+    atop_base_request_t atop_request = {
+        .path      = "/d.json",
+        .key       = client->secret_key,
+        .api       = request->api,
+        .version   = request->version,
+        .devid     = client->devid,
+        .timestamp = (uint32_t)time(NULL),
+        .data      = (void *)body,
+        .datalen   = strlen(body),
+        .host      = host[0] ? host : NULL,
+        .port      = port,
+        .cacert    = client->cacert,
+        .cert_bundle_attach = client->cert_bundle_attach,
+    };
+
+    atop_base_response_t atop_response = {0};
+    rt = atop_base_request(client->pal, &atop_request, &atop_response);
+
+    /* Carry the cloud's verdict back on every path. For a generic call this is
+     * the whole point: the caller knows what its interface can reject on, and
+     * the SDK does not. */
+    snprintf(response->error_code, sizeof(response->error_code), "%s",
+             atop_response.error_code);
+    snprintf(response->error_msg, sizeof(response->error_msg), "%s",
+             atop_response.error_msg);
+    response->server_time = atop_response.t;
+
+    if (rt != OPRT_OK) {
+        log_error("iot_atop_call(%s v%s) failed: %d", request->api,
+                  request->version, rt);
+        atop_base_response_free(client->pal, &atop_response);
+        return rt;
+    }
+
+    /* An absent result and a JSON null result both mean "nothing to report":
+     * response->result stays NULL and the caller sees OPRT_OK. Without the
+     * IsNull check a {"result":null} envelope would come back as the
+     * four-character string "null", which the header explicitly rules out. */
+    if (atop_response.result != NULL && !cJSON_IsNull(atop_response.result)) {
+        /* The printed string is already pal-owned -- cJSON's hooks are the pal
+         * allocator (cJSON_InitHooks in iot_init), and no successful response
+         * can precede iot_init(): the AES-GCM nonce needs rng_bytes(), which
+         * fails closed until rng_init() runs inside that same function. Same
+         * reasoning as iot_dp_dump_json (iot_dp.c). */
+        response->result = cJSON_PrintUnformatted(atop_response.result);
+        if (response->result == NULL) {
+            atop_base_response_free(client->pal, &atop_response);
+            return OPRT_MALLOC_FAILED;
+        }
+    }
+
+    atop_base_response_free(client->pal, &atop_response);
+    return OPRT_OK;
+}
+
+void iot_atop_response_free(iot_client_t *client, iot_atop_response_t *response)
+{
+    if (client == NULL || client->pal == NULL || response == NULL) {
+        return;
+    }
+    if (response->result != NULL) {
+        client->pal->free(response->result);
+    }
+    memset(response, 0, sizeof(*response));
+}

--- a/modules/iot-client/src/iot_on_boarding.c
+++ b/modules/iot-client/src/iot_on_boarding.c
@@ -327,6 +327,11 @@ static int activate_device(const pal_t *pal, on_boarding_config_t *on_boarding, 
             case OPRT_COMMUNICATION_ERROR:
                 log_error("  - Communication error");
                 break;
+            case OPRT_ATOP_BUSINESS_ERROR:
+                /* e.g. an expired/used pairing token -- the cloud's errorCode
+                 * and errorMsg are logged by the envelope layer just above. */
+                log_error("  - Rejected by the cloud (see errorCode above)");
+                break;
             case OPRT_TLS_HANDSHAKE_FAILED:
                 log_error("  - TLS handshake failed");
                 break;

--- a/modules/iot-client/test/atop_test.c
+++ b/modules/iot-client/test/atop_test.c
@@ -11,7 +11,10 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#include <time.h>
+
 #include "atop.h"
+#include "atop_base.h"
 #include "iot_client.h"
 #include "iot_config_defaults.h"
 
@@ -580,6 +583,93 @@ static int test_device_meta_save_missing_meta(void)
 
 /* ---------- main ---------- */
 
+/* ---------- P0: the envelope error contract ---------- */
+
+/* tuya.device.versions.update rejects a body without "versions" with
+ * errorCode ILLEGAL_PARAM. That envelope must be an error carrying the code --
+ * before the fix it came back as OPRT_OK with result=NULL, so every caller that
+ * only checked the return value silently treated a rejection as success. */
+static int test_envelope_rejection_is_an_error(void)
+{
+    const pal_t *pal = get_default_pal();
+    char body[64];
+    snprintf(body, sizeof(body), "{\"t\":%u}", (unsigned)time(NULL));
+
+    atop_base_request_t req = {
+        .path      = "/d.json",
+        .key       = TEST_SEC_KEY,
+        .devid     = TEST_DEVID,
+        .api       = "tuya.device.versions.update",
+        .version   = "4.1",
+        .timestamp = (uint32_t)time(NULL),
+        .data      = body,
+        .datalen   = strlen(body),
+        .host      = MOCK_HOST,
+        .port      = MOCK_PORT,
+        .cacert    = g_cacert,
+    };
+
+    atop_base_response_t resp = {0};
+    int rt = atop_base_request(pal, &req, &resp);
+
+    if (rt != OPRT_ATOP_BUSINESS_ERROR) {
+        printf("  returned %d, expected OPRT_ATOP_BUSINESS_ERROR (%d)\n",
+               rt, OPRT_ATOP_BUSINESS_ERROR);
+        atop_base_response_free(pal, &resp);
+        return -1;
+    }
+    if (resp.success != false) {
+        printf("  success flag should be false\n");
+        atop_base_response_free(pal, &resp);
+        return -1;
+    }
+    if (strcmp(resp.error_code, "ILLEGAL_PARAM") != 0) {
+        printf("  error_code is \"%s\", expected \"ILLEGAL_PARAM\"\n", resp.error_code);
+        atop_base_response_free(pal, &resp);
+        return -1;
+    }
+    if (resp.error_msg[0] == '\0') {
+        printf("  error_msg was not carried out of the envelope\n");
+        atop_base_response_free(pal, &resp);
+        return -1;
+    }
+    printf("  rejection surfaced: %s (%s)\n", resp.error_code, resp.error_msg);
+    atop_base_response_free(pal, &resp);
+    return 0;
+}
+
+/* The success path must not have moved: an empty result is still OPRT_OK with
+ * no error code, which is what distinguishes "nothing to report" from a
+ * rejection now that the two return different codes. */
+static int test_empty_result_is_still_success(void)
+{
+    const pal_t *pal = get_default_pal();
+    schema_newest_request_t req = {
+        .devid     = TEST_DEVID,
+        .key       = TEST_SEC_KEY,
+        .schema_id = "test_schema_id",
+        .version   = "NOUPDATE",   /* mock sentinel: returns result [] */
+        .host      = MOCK_HOST,
+        .port      = MOCK_PORT,
+        .cacert    = g_cacert,
+    };
+
+    schema_newest_response_t resp = {0};
+    int rt = atop_schema_newest_get(pal, &req, &resp);
+    if (rt != OPRT_OK) {
+        printf("  returned %d, expected OPRT_OK for the no-update case\n", rt);
+        atop_schema_newest_response_free(pal, &resp);
+        return -1;
+    }
+    if (resp.updated) {
+        printf("  reported an update for the NOUPDATE sentinel\n");
+        atop_schema_newest_response_free(pal, &resp);
+        return -1;
+    }
+    atop_schema_newest_response_free(pal, &resp);
+    return 0;
+}
+
 int main(void)
 {
     printf("========== ATOP Test Suite ==========\n");
@@ -598,6 +688,10 @@ int main(void)
         fprintf(stderr, "Failed to start mock server\n");
         return 1;
     }
+
+    /* Envelope error contract */
+    RUN_TEST(test_envelope_rejection_is_an_error);
+    RUN_TEST(test_empty_result_is_still_success);
 
     /* Parameter validation tests */
     RUN_TEST(test_activate_null_params);

--- a/modules/iot-client/test/iot_atop_call_test.c
+++ b/modules/iot-client/test/iot_atop_call_test.c
@@ -1,0 +1,540 @@
+/**
+ * @file iot_atop_call_test.c
+ * @brief Tests for the generic ATOP entry point (iot_atop_call).
+ *
+ * Covers argument guards, the credential requirement, body validation, result
+ * pass-through and error pass-through. The envelope error contract this relies
+ * on is tested in atop_test.c.
+ *
+ * The client is a stack iot_client_t with devid/secret_key/https_url set, so no
+ * activation or MQTT connection is needed; https_url points the ATOP host
+ * resolution at the mock server.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <time.h>
+
+#include "iot_atop.h"
+#include "iot_client.h"
+#include "iot_config_defaults.h"
+
+#define MOCK_HOST "127.0.0.1"
+#define MOCK_PORT 8443
+
+/* Must match test/config/atop.conf (device_id / sec_key). */
+#define TEST_DEVID   "ci_device_test_001"
+#define TEST_SEC_KEY "1234567890abcdef"
+
+static pid_t mock_pid = -1;
+static int tests_run = 0;
+static int tests_passed = 0;
+static char *g_cacert = NULL;
+static iot_client_t g_client;
+
+static char *load_file(const pal_t *pal, const char *path)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = pal->malloc(len + 1);
+    if (buf) {
+        size_t read_len = fread(buf, 1, len, f);
+        if (read_len != (size_t)len) {
+            pal->free(buf);
+            fclose(f);
+            return NULL;
+        }
+        buf[len] = '\0';
+    }
+    fclose(f);
+    return buf;
+}
+
+#define RUN_TEST(fn)                                       \
+    do {                                                   \
+        tests_run++;                                       \
+        printf("\n--- [%d] %s ---\n", tests_run, #fn);     \
+        if ((fn)() == 0) {                                 \
+            tests_passed++;                                \
+            printf("  PASS\n");                            \
+        } else {                                           \
+            printf("  FAIL\n");                            \
+        }                                                  \
+    } while (0)
+
+/* ---------- Mock server lifecycle (same probe as iot_ota_test) ---------- */
+
+static int wait_for_port(uint16_t port, int timeout_ms)
+{
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port   = htons(port);
+    inet_pton(AF_INET, MOCK_HOST, &addr.sin_addr);
+
+    const int step_ms = 50;
+    for (int waited = 0; waited <= timeout_ms; waited += step_ms) {
+        int fd = socket(AF_INET, SOCK_STREAM, 0);
+        if (fd >= 0) {
+            int fl = fcntl(fd, F_GETFL, 0);
+            fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+            int rc = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
+            if (rc == 0) { close(fd); return 0; }
+            if (rc < 0 && errno == EINPROGRESS) {
+                fd_set wfds; FD_ZERO(&wfds); FD_SET(fd, &wfds);
+                struct timeval tv = { .tv_sec = 0, .tv_usec = 300 * 1000 };
+                if (select(fd + 1, NULL, &wfds, NULL, &tv) > 0) {
+                    int err = 0; socklen_t len = sizeof(err);
+                    getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &len);
+                    if (err == 0) { close(fd); return 0; }
+                }
+            }
+            close(fd);
+        }
+        usleep(step_ms * 1000);
+    }
+    return -1;
+}
+
+static int start_mock_server(void)
+{
+    mock_pid = fork();
+    if (mock_pid == 0) {
+        setenv("ATOP_MOCK_USE_SSL", "1", 1);
+        execlp(PYTHON3_EXEC, PYTHON3_EXEC, MOCK_SCRIPT_PATH, NULL);
+        perror("execlp failed");
+        _exit(1);
+    }
+    if (mock_pid < 0) {
+        perror("fork");
+        return -1;
+    }
+    printf("Mock server started (pid %d, port %u), waiting for ready...\n", mock_pid, MOCK_PORT);
+    if (wait_for_port(MOCK_PORT, 15000) != 0) {
+        fprintf(stderr, "ATOP mock (%u) never became connectable\n", MOCK_PORT);
+        return -1;
+    }
+    return 0;
+}
+
+static void stop_mock_server(void)
+{
+    if (mock_pid > 0) {
+        printf("Stopping mock server (pid %d)...\n", mock_pid);
+        kill(mock_pid, SIGTERM);
+        waitpid(mock_pid, NULL, 0);
+        mock_pid = -1;
+    }
+}
+
+/* ---------- iot_atop_call: guards ---------- */
+
+static int test_null_params(void)
+{
+    iot_atop_request_t req = { .api = "tuya.device.meta.save", .version = "1.0" };
+    iot_atop_response_t resp = {0};
+
+    if (iot_atop_call(NULL, &req, &resp) != OPRT_INVALID_PARAMETER ||
+        iot_atop_call(&g_client, NULL, &resp) != OPRT_INVALID_PARAMETER ||
+        iot_atop_call(&g_client, &req, NULL) != OPRT_INVALID_PARAMETER) {
+        printf("  NULL guards failed\n");
+        return -1;
+    }
+    iot_atop_response_free(&g_client, NULL);  /* must be a safe no-op */
+    return 0;
+}
+
+static int test_api_and_version_required(void)
+{
+    iot_atop_response_t resp = {0};
+    const iot_atop_request_t bad[] = {
+        { .api = NULL,                       .version = "1.0" },
+        { .api = "",                         .version = "1.0" },
+        { .api = "tuya.device.meta.save",    .version = NULL  },
+        { .api = "tuya.device.meta.save",    .version = ""    },
+    };
+
+    for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); i++) {
+        int rt = iot_atop_call(&g_client, &bad[i], &resp);
+        if (rt != OPRT_INVALID_PARAMETER) {
+            printf("  case %zu returned %d, expected OPRT_INVALID_PARAMETER\n", i, rt);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int test_requires_device_credentials(void)
+{
+    iot_client_t bare = g_client;
+    bare.devid[0] = '\0';
+
+    iot_atop_request_t req = { .api = "tuya.device.meta.save", .version = "1.0" };
+    iot_atop_response_t resp = {0};
+
+    int rt = iot_atop_call(&bare, &req, &resp);
+    if (rt != OPRT_UNINITIALIZED) {
+        printf("  returned %d, expected OPRT_UNINITIALIZED\n", rt);
+        return -1;
+    }
+
+    bare = g_client;
+    bare.secret_key[0] = '\0';
+    rt = iot_atop_call(&bare, &req, &resp);
+    if (rt != OPRT_UNINITIALIZED) {
+        printf("  empty secret_key returned %d, expected OPRT_UNINITIALIZED\n", rt);
+        return -1;
+    }
+    return 0;
+}
+
+/* A malformed body is caught locally, before spending an HTTPS round trip. */
+static int test_body_must_be_json_object(void)
+{
+    iot_atop_response_t resp = {0};
+    const char *bad_bodies[] = {
+        "{not json",
+        "[1,2,3]",      /* valid JSON, but an array is not a request body */
+        "\"string\"",
+        "42",
+        "{}garbage",    /* trailing garbage after a complete value */
+        "{\"t\":1}}",
+    };
+
+    for (size_t i = 0; i < sizeof(bad_bodies) / sizeof(bad_bodies[0]); i++) {
+        iot_atop_request_t req = { .api = "tuya.device.meta.save",
+                                   .version = "1.0",
+                                   .data = bad_bodies[i] };
+        int rt = iot_atop_call(&g_client, &req, &resp);
+        if (rt != OPRT_INVALID_PARAMETER) {
+            printf("  body %zu (%s) returned %d, expected OPRT_INVALID_PARAMETER\n",
+                   i, bad_bodies[i], rt);
+            iot_atop_response_free(&g_client, &resp);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* ---------- iot_atop_call: round trips ---------- */
+
+static int test_call_returns_result_json(void)
+{
+    char body[128];
+    snprintf(body, sizeof(body),
+             "{\"metas\":{\"smain_network_sdk_full_version\":\"test 0.1\"},\"t\":%u}",
+             (unsigned)time(NULL));
+
+    iot_atop_request_t req = { .api = "tuya.device.meta.save",
+                               .version = "1.0",
+                               .data = body };
+    iot_atop_response_t resp = {0};
+
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    if (rt != OPRT_OK) {
+        printf("  returned %d (%s / %s), expected OPRT_OK\n",
+               rt, resp.error_code, resp.error_msg);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (resp.error_code[0] != '\0') {
+        printf("  error_code should be empty on success, got \"%s\"\n", resp.error_code);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (resp.result == NULL || strcmp(resp.result, "true") != 0) {
+        printf("  result is \"%s\", expected \"true\"\n",
+               resp.result ? resp.result : "(null)");
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (resp.server_time <= 0) {
+        printf("  server_time was not carried out of the envelope\n");
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    printf("  result=%s server_time=%d\n", resp.result, resp.server_time);
+    iot_atop_response_free(&g_client, &resp);
+    return 0;
+}
+
+/* A non-scalar result comes back as its JSON text, unparsed -- that is the
+ * contract: cJSON stays out of the public ABI. */
+static int test_call_returns_json_array(void)
+{
+    char body[160];
+    snprintf(body, sizeof(body),
+             "{\"schemaId\":\"test_schema_id\",\"version\":\"\",\"t\":%u}",
+             (unsigned)time(NULL));
+
+    iot_atop_request_t req = { .api = "tuya.device.schema.newest.get",
+                               .version = "1.0",
+                               .data = body };
+    iot_atop_response_t resp = {0};
+
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    if (rt != OPRT_OK || resp.result == NULL) {
+        printf("  returned %d, result=%s\n", rt, resp.result ? resp.result : "(null)");
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (resp.result[0] != '[') {
+        printf("  expected a JSON array, got: %.40s\n", resp.result);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    printf("  result=%.60s...\n", resp.result);
+    iot_atop_response_free(&g_client, &resp);
+    return 0;
+}
+
+/* A NULL body means "{}" -- enough for interfaces that take no arguments. */
+static int test_null_body_defaults_to_empty_object(void)
+{
+    iot_atop_request_t req = { .api = "tuya.device.schema.newest.get",
+                               .version = "1.0",
+                               .data = NULL };
+    iot_atop_response_t resp = {0};
+
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    if (rt != OPRT_OK) {
+        printf("  returned %d (%s), expected OPRT_OK\n", rt, resp.error_code);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    iot_atop_response_free(&g_client, &resp);
+    return 0;
+}
+
+/* A {"result":null} envelope means "nothing to report" -- it must come back as
+ * a NULL pointer, never as the four-character string "null". */
+static int test_null_result_stays_null(void)
+{
+    char body[64];
+    snprintf(body, sizeof(body), "{\"t\":%u}", (unsigned)time(NULL));
+
+    iot_atop_request_t req = { .api = "tuya.test.result.null",
+                               .version = "1.0",
+                               .data = body };
+    iot_atop_response_t resp = {0};
+
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    if (rt != OPRT_OK) {
+        printf("  returned %d (%s), expected OPRT_OK\n", rt, resp.error_code);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (resp.result != NULL) {
+        printf("  result is \"%s\", expected NULL for a JSON null\n", resp.result);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    iot_atop_response_free(&g_client, &resp);
+    return 0;
+}
+
+/* GATEWAY_NOT_EXISTS historically mapped to OPRT_COMMUNICATION_ERROR, which the
+ * documented return-code table classifies as retryable transport failure -- a
+ * permanent-retry trap for a device that was deleted from the cloud. Pin the
+ * uniform verdict so the special case cannot quietly come back. */
+static int test_gateway_not_exists_is_business_error(void)
+{
+    char body[64];
+    snprintf(body, sizeof(body), "{\"t\":%u}", (unsigned)time(NULL));
+
+    iot_atop_request_t req = { .api = "tuya.test.gateway.gone",
+                               .version = "1.0",
+                               .data = body };
+    iot_atop_response_t resp = {0};
+
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    if (rt != OPRT_ATOP_BUSINESS_ERROR) {
+        printf("  returned %d, expected OPRT_ATOP_BUSINESS_ERROR\n", rt);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (strcmp(resp.error_code, "GATEWAY_NOT_EXISTS") != 0) {
+        printf("  error_code is \"%s\"\n", resp.error_code);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    printf("  uniform verdict: %s -> OPRT_ATOP_BUSINESS_ERROR\n", resp.error_code);
+    iot_atop_response_free(&g_client, &resp);
+    return 0;
+}
+
+/* The header promises "zeroed on entry" on EVERY path, including the argument
+ * guards -- a stale error_code surviving a rejected call must not masquerade
+ * as this call's cloud verdict. */
+static int test_response_zeroed_on_bad_request(void)
+{
+    iot_atop_response_t resp;
+    memset(&resp, 0xAA, sizeof(resp));   /* poison, as stack garbage would */
+
+    iot_atop_request_t req = { .api = "", .version = "1.0" };
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    if (rt != OPRT_INVALID_PARAMETER) {
+        printf("  returned %d, expected OPRT_INVALID_PARAMETER\n", rt);
+        return -1;
+    }
+    if (resp.result != NULL || resp.error_code[0] != '\0' || resp.server_time != 0) {
+        printf("  response was not zeroed on the early-return path\n");
+        return -1;
+    }
+    iot_atop_response_free(&g_client, &resp);   /* must be safe, per the header */
+    return 0;
+}
+
+/* The whole point of the generic entry: the caller knows what its interface
+ * rejects on, so the cloud's own code has to reach it. */
+static int test_business_error_carries_error_code(void)
+{
+    char body[64];
+    snprintf(body, sizeof(body), "{\"t\":%u}", (unsigned)time(NULL));  /* no "metas" */
+
+    iot_atop_request_t req = { .api = "tuya.device.meta.save",
+                               .version = "1.0",
+                               .data = body };
+    iot_atop_response_t resp = {0};
+
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    if (rt != OPRT_ATOP_BUSINESS_ERROR) {
+        printf("  returned %d, expected OPRT_ATOP_BUSINESS_ERROR\n", rt);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (strcmp(resp.error_code, "ILLEGAL_PARAM") != 0) {
+        printf("  error_code is \"%s\", expected \"ILLEGAL_PARAM\"\n", resp.error_code);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (resp.result != NULL) {
+        printf("  result should be NULL on rejection\n");
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    printf("  rejected with %s (%s)\n", resp.error_code, resp.error_msg);
+    iot_atop_response_free(&g_client, &resp);
+    return 0;
+}
+
+/* An interface the SDK has never heard of still gets a usable answer -- this is
+ * what unblocks a business layer from waiting on an SDK release. */
+static int test_unknown_api_reaches_the_cloud(void)
+{
+    char body[64];
+    snprintf(body, sizeof(body), "{\"t\":%u}", (unsigned)time(NULL));
+
+    iot_atop_request_t req = { .api = "tuya.device.role.list.get",
+                               .version = "1.0",
+                               .data = body };
+    iot_atop_response_t resp = {0};
+
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    if (rt != OPRT_ATOP_BUSINESS_ERROR) {
+        printf("  returned %d, expected OPRT_ATOP_BUSINESS_ERROR\n", rt);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    if (strcmp(resp.error_code, "UNKNOWN_API") != 0) {
+        printf("  error_code is \"%s\", expected \"UNKNOWN_API\"\n", resp.error_code);
+        iot_atop_response_free(&g_client, &resp);
+        return -1;
+    }
+    printf("  signed, encrypted and delivered; cloud replied %s\n", resp.error_code);
+    iot_atop_response_free(&g_client, &resp);
+    return 0;
+}
+
+static int test_response_free_is_repeatable(void)
+{
+    iot_atop_response_t resp = {0};
+
+    iot_atop_response_free(&g_client, &resp);   /* all-zero struct */
+
+    char body[128];
+    snprintf(body, sizeof(body),
+             "{\"metas\":{\"k\":\"v\"},\"t\":%u}", (unsigned)time(NULL));
+    iot_atop_request_t req = { .api = "tuya.device.meta.save",
+                               .version = "1.0",
+                               .data = body };
+    if (iot_atop_call(&g_client, &req, &resp) != OPRT_OK) {
+        printf("  setup call failed\n");
+        return -1;
+    }
+
+    iot_atop_response_free(&g_client, &resp);
+    if (resp.result != NULL || resp.error_code[0] != '\0' || resp.server_time != 0) {
+        printf("  free did not zero the struct\n");
+        return -1;
+    }
+    iot_atop_response_free(&g_client, &resp);   /* double free must be safe */
+    return 0;
+}
+
+int main(void)
+{
+    printf("========== ATOP Generic Call Test Suite ==========\n");
+
+    const pal_t *pal = get_default_pal();
+    iot_init(pal);
+
+    g_cacert = load_file(pal, TEST_CONFIG_DIR "/root_cert.pem");
+    if (!g_cacert) {
+        fprintf(stderr, "Failed to load CA certificate from %s\n",
+                TEST_CONFIG_DIR "/root_cert.pem");
+        return 1;
+    }
+
+    /* A stack client is enough: iot_atop_call() only reads credentials, the
+     * resolved ATOP endpoint, and the TLS settings. */
+    memset(&g_client, 0, sizeof(g_client));
+    g_client.pal = pal;
+    snprintf(g_client.devid, sizeof(g_client.devid), "%s", TEST_DEVID);
+    snprintf(g_client.secret_key, sizeof(g_client.secret_key), "%s", TEST_SEC_KEY);
+    snprintf(g_client.https_url, sizeof(g_client.https_url),
+             "https://%s:%u", MOCK_HOST, MOCK_PORT);
+    g_client.cacert = g_cacert;
+
+    if (start_mock_server() != 0) {
+        fprintf(stderr, "Failed to start mock server\n");
+        pal->free(g_cacert);
+        return 1;
+    }
+
+    /* Guards — no network needed */
+    RUN_TEST(test_null_params);
+    RUN_TEST(test_api_and_version_required);
+    RUN_TEST(test_requires_device_credentials);
+    RUN_TEST(test_body_must_be_json_object);
+
+    /* Round trips */
+    RUN_TEST(test_call_returns_result_json);
+    RUN_TEST(test_call_returns_json_array);
+    RUN_TEST(test_null_body_defaults_to_empty_object);
+    RUN_TEST(test_business_error_carries_error_code);
+    RUN_TEST(test_unknown_api_reaches_the_cloud);
+    RUN_TEST(test_null_result_stays_null);
+    RUN_TEST(test_gateway_not_exists_is_business_error);
+    RUN_TEST(test_response_zeroed_on_bad_request);
+    RUN_TEST(test_response_free_is_repeatable);
+
+    stop_mock_server();
+    pal->free(g_cacert);
+
+    printf("\n========== Results: %d/%d passed ==========\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/modules/iot-client/test/mock/atop_mock.py
+++ b/modules/iot-client/test/mock/atop_mock.py
@@ -555,21 +555,13 @@ class ATOPMockHandler(BaseHTTPRequestHandler):
             # Determine encryption key
             # For activation: use authkey from config
             # For AI config: use sec_key from config (or devid's key)
-            if api == 'thing.device.opensdk.active':
-                key = self.config.get('authkey', '').encode('utf-8')
-            elif api == 'thing.ai.agent.token.get':
-                key = self.config.get('sec_key', '').encode('utf-8')
-            elif api == 'tuya.device.qrcode.info.get':
-                key = self.config.get('authkey', '').encode('utf-8')
-            elif api == 'tuya.device.meta.save':
-                key = self.config.get('sec_key', '').encode('utf-8')
-            elif api == 'tuya.device.schema.newest.get':
-                key = self.config.get('sec_key', '').encode('utf-8')
-            elif api == 'tuya.device.upgrade.get':
-                key = self.config.get('sec_key', '').encode('utf-8')
-            elif api == 'tuya.device.versions.update':
-                key = self.config.get('sec_key', '').encode('utf-8')
-            elif api == 'tuya.device.upgrade.status.update':
+            # Key selection follows the credential the device signs with, keyed
+            # purely off the identity param in the URL: a devId means the caller
+            # is an activated device signing with sec_key; otherwise (uuid-only,
+            # i.e. pre-activation) it signs with authkey. No per-API list -- that
+            # is what lets the generic entry point reach interfaces the mock has
+            # no handler for, including ones the named wrappers also cover.
+            if devid:
                 key = self.config.get('sec_key', '').encode('utf-8')
             else:
                 key = self.config.get('authkey', '').encode('utf-8')
@@ -615,6 +607,24 @@ class ATOPMockHandler(BaseHTTPRequestHandler):
                 response_json = handle_version_update(decrypted_data, self.config)
             elif api == 'tuya.device.upgrade.status.update':
                 response_json = handle_upgrade_status_update(decrypted_data, self.config)
+            elif api == 'tuya.test.result.null':
+                # Test-only: a success envelope whose result is JSON null --
+                # the generic entry must hand this back as NULL, not "null".
+                response_json = json.dumps({
+                    "success": True,
+                    "t": int(time.time()),
+                    "result": None
+                }, separators=(',', ':'))
+            elif api == 'tuya.test.gateway.gone':
+                # Test-only: the errorCode that historically had a special
+                # OPRT_COMMUNICATION_ERROR mapping; it must now be the same
+                # uniform business error as every other rejection.
+                response_json = json.dumps({
+                    "success": False,
+                    "t": int(time.time()),
+                    "errorCode": "GATEWAY_NOT_EXISTS",
+                    "errorMsg": "device removed from the cloud"
+                }, separators=(',', ':'))
             else:
                 response_json = json.dumps({
                     "success": False,


### PR DESCRIPTION
## Summary

The SDK wraps eight ATOP interfaces by name; the cloud has many more. Reaching one of the
others meant waiting for an SDK release, or reaching into `src/atop_base.h` — which the
build permits but which is undocumented, untested, and free to change. This adds a
supported entry point for them, plus the envelope fix it depends on.

## `iot_atop_call()`

New public header `iot_atop.h`: an `api` name, its `version` and a JSON body in; the
envelope's `result` out as a JSON string, plus the cloud's `errorCode` / `errorMsg` and
server time. Signing, AES-GCM body encryption, TLS, host resolution and envelope parsing
stay inside the SDK.

- Takes `iot_client_t` (following `iot_ota.c`), so the caller never handles the device
  secret key and cannot forget the CA bundle.
- `result` is a JSON string, not `cJSON *` — keeps cJSON out of the public ABI and memory
  ownership on one side (`iot_atop_response_free`). `{"result":null}` comes back as `NULL`,
  not `"null"`.
- Activated devices only; `OPRT_UNINITIALIZED` otherwise. Activation signs with
  `uuid` + `authkey` and stays behind `iot_client_init_on_boarding()`.
- Request bodies pass through verbatim — including the `t` field most interfaces expect —
  validated only as "parses as a JSON object with nothing trailing", so a typo fails
  locally instead of costing an HTTPS round trip.

## Breaking: rejections now have their own return code

The envelope used to log `errorCode` / `errorMsg`, drop them, and return `OPRT_OK`.
Detecting a rejection meant inspecting `atop_base_response_t.success` separately, and only
three of the eight wrappers did. Worst case: a rejected `tuya.device.schema.newest.get`
arrived as `OPRT_OK` with `result == NULL`, which `atop_schema_newest_get()` reports as "no
newer schema" — a permission error was indistinguishable from an up-to-date schema.

Rejections now carry `error_code` / `error_msg` on the response and return a new
`OPRT_ATOP_BUSINESS_ERROR` (`-0x000E`), uniformly. Two consequences for existing code:

- Named wrappers return `-0x000E` where a rejection previously surfaced as
  `OPRT_OK`-with-empty-result, or as `OPRT_COMMUNICATION_ERROR` in two of them.
- `GATEWAY_NOT_EXISTS` loses its `OPRT_COMMUNICATION_ERROR` mapping — it presented a
  permanent "device removed from the cloud" verdict as a retryable transport failure.
  Branch on `error_code` for per-code policy.

## Testing

Full suite **13/13**, POSIX examples build clean.

It was 12 before this branch: `include(CTest)` only calls `enable_testing()` while
`BUILD_TESTING` is ON, which we FORCE off to silence the vendored suites, so re-configures
had silently stopped regenerating the ctest list — `iot_ota_verify_test` (from #17) and
this branch's `iot_atop_call_test` compiled without ever running. Fixed here.

`iot_atop_call_test` is 13 cases, with two mock vectors pinning the `result: null` and
rejection paths; two cases in `atop_test.c` pin the envelope contract itself.

Docs: new guide `atop-generic-call.md`, including the criteria for promoting an interface
to a named wrapper; ATOP vocabulary added to `modules/iot-client/CONTEXT.md`; CHANGELOG and
`sidebars.ts` updated.
