### PR TITLE
feat(iot-client): add APP-confirmed OTA flow

### DIFF
--- a/docs-site/docs/guides/ota-upgrade.md
+++ b/docs-site/docs/guides/ota-upgrade.md
@@ -8,7 +8,9 @@ sidebar_position: 6
 
 本指南说明如何使用 agentic-kit 的 `iot_ota` API 实现设备固件 OTA（Over-The-Air）升级。
 
-SDK 只提供**云端协议原语**——版本上报、升级查询、状态回报；**固件的下载与烧写由应用负责**（例如 ESP-IDF 的 `esp_ota_*` 或厂商自有的 bootloader API）。完整示例见 `examples/esp-idf/ota-demo`。
+SDK 只提供**云端协议原语**——版本上报、升级查询、状态回报，以及 APP 确认通知回调；**固件的下载与烧写由应用负责**（例如 ESP-IDF 的 `esp_ota_*` 或厂商自有的 bootloader API）。完整主动查询示例见 `examples/esp-idf/ota-demo`。
+
+如果产品要求“用户在 APP 上确认后才允许升级”，请将云端 OTA 任务配置为 APP 确认模式，并在设备上注册 `ota_confirm_callback`。agentic-kit 不调用 `tuya.device.upgrade.silent.get`，因此不会主动拉取或执行静默升级任务。
 
 ## 工作原理
 
@@ -43,6 +45,72 @@ SDK 只提供**云端协议原语**——版本上报、升级查询、状态回
 | `iot_ota_check_upgrade` | `tuya.device.upgrade.get` (v4.4) | 查询是否有待升级固件，返回 URL / 版本 / 大小 / 哈希（云端与已上报的版本比较，不再传版本号） |
 | `iot_ota_report_status` | `tuya.device.upgrade.status.update` (v4.1) | 回报升级生命周期状态 |
 | `iot_ota_verify_init/update/finish` | — | 流式校验下载固件的 md5/hmac 摘要（见下文） |
+
+## APP 确认后触发升级
+
+APP 确认升级后，云端通过 MQTT 协议号 `15` 通知设备。SDK 解密后读取 `data.firmwareType` 作为固件 channel，并调用 `ota_confirm_callback`：
+
+```c
+static volatile bool g_ota_confirmed;
+static volatile int g_ota_channel;
+
+static void on_ota_confirmed(int channel, void *user_data)
+{
+    (void)user_data;
+    g_ota_confirmed = true;   /* 只做轻量通知，不阻塞 MQTT process 线程 */
+    g_ota_channel = channel;
+}
+
+iot_client_config_t cfg = {
+    /* ... */
+    .ota_confirm_callback = on_ota_confirmed,
+    .ota_confirm_user_data = NULL,
+};
+```
+
+应用主循环或专用 OTA 工作线程收到该信号后，再执行升级原语：
+
+```text
+APP 点击确认 ──> 云端下发 MQTT protocol 15
+                     │
+                     v
+        ota_confirm_callback(channel)          /* SDK 只通知，不升级 */
+                     │
+              应用 worker 唤醒
+                     │
+                     v
+        iot_ota_check_upgrade(client, channel, &info)
+                     │
+                 有升级？
+                 /     \
+               否       是
+               │        │
+           保持运行   report_status(UPGRADING)
+                         │
+                         v
+                  下载 + 校验 + 烧写          /* 应用实现 */
+                         │
+                成功 / 失败
+                  │       │
+        report_status    report_status
+          (COMPLETE)       (ERROR)
+```
+
+```c
+iot_ota_upgrade_info_t info = {0};
+if (!g_ota_confirmed) {
+    /* 等待确认信号 */
+}
+
+int rc = iot_ota_check_upgrade(client, g_ota_channel, &info);
+if (rc == OPRT_OK && info.has_upgrade) {
+    rc = iot_ota_report_status(client, info.channel, OTA_STATUS_UPGRADING);
+    /* 在应用线程执行下载、iot_ota_verify_* 校验和平台 OTA 烧写 */
+}
+iot_ota_upgrade_info_free(client, &info);
+```
+
+`ota_confirm_callback` 与 `message_callback` 一样运行在调用 `iot_client_process()` / `iot_client_message_process()` 的线程内，coreMQTT 回调返回后还要继续处理 ack 和网络缓冲。回调中只允许置位标志、释放信号量或投递工作项；不要调用 `iot_ota_check_upgrade()`、下载固件、写 flash，也不要断开或销毁 IoT client。未注册该回调时，protocol 15 会继续透传给 `message_callback`，兼容旧应用自行解析的用法。
 
 ### `iot_ota_check_upgrade` 返回的升级信息
 
@@ -289,6 +357,7 @@ idf flash monitor
 ## 注意事项
 
 - **SDK 不下载/不烧写**——`iot_ota` 只负责云端协议；下载校验、分区管理、防回滚全部由应用实现。
+- **APP 确认模式**——云端任务需配置为 APP 确认模式；设备侧通过 `ota_confirm_callback` 接收 protocol 15，再由应用 worker 查询并执行升级。SDK 不调用静默升级接口。
 - **栈要足够大**——TLS 握手 + HTTP 缓冲 + `esp_ota_write` 需要较大栈空间（demo 用 16KB）。
 - **回报时机**——`UPGRADING` 在下载前、`COMPLETE` 在重启前、`ERROR` 在失败时；漏报会导致云端升级面板状态不准。
 - **MD5/HMAC 摘要校验**——`iot_ota_verify_init/update/finish` 在下载时流式计算摘要，`esp_ota_set_boot_partition` **之前**完成校验；不匹配必须中止升级（见上文「固件摘要校验」）。

--- a/docs-site/docs/reference/iot-client.md
+++ b/docs-site/docs/reference/iot-client.md
@@ -110,6 +110,8 @@ IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.
 | `message_callback` | `iot_message_callback_t` | MQTT 消息回调，可为 NULL |
 | `reset_callback` | `iot_reset_callback_t` | 云端解绑/恢复出厂（protocol 11）通知回调，可为 NULL。注册后 protocol 11 消息由 SDK 消费，不再进入 `message_callback` |
 | `reset_user_data` | `void *` | 透传给 `reset_callback` 的用户指针，可为 NULL |
+| `ota_confirm_callback` | `iot_ota_confirm_callback_t` | APP 确认 OTA 升级（protocol 15）通知回调，可为 NULL。注册后 protocol 15 消息由 SDK 消费，不再进入 `message_callback` |
+| `ota_confirm_user_data` | `void *` | 透传给 `ota_confirm_callback` 的用户指针，可为 NULL |
 | `schema` | `const char *` | 重启时用于恢复的 DP schema JSON（调用方持有，NULL = 不恢复 / 宽松模式） |
 | `schema_id` | `const char *` | 持久化的 schema id（schema 升级查询的稳定 key，可为 NULL） |
 | `dp_state` | `const char *` | 持久化的 DP 当前状态 `{"dps":{...}}`，用于恢复（不置脏、不上报，可为 NULL） |
@@ -137,6 +139,8 @@ IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.
 | `message_callback` | `iot_message_callback_t` | MQTT 消息回调 |
 | `reset_callback` | `iot_reset_callback_t` | 云端解绑/恢复出厂（protocol 11）通知回调，可为 NULL。注册后 protocol 11 消息由 SDK 消费，不再进入 `message_callback` |
 | `reset_user_data` | `void *` | 透传给 `reset_callback` 的用户指针，可为 NULL |
+| `ota_confirm_callback` | `iot_ota_confirm_callback_t` | APP 确认 OTA 升级（protocol 15）通知回调，可为 NULL。注册后 protocol 15 消息由 SDK 消费，不再进入 `message_callback` |
+| `ota_confirm_user_data` | `void *` | 透传给 `ota_confirm_callback` 的用户指针，可为 NULL |
 | `sw_ver` | `const char *` | 应用固件版本号（如 `"1.2.3"`），激活后自动上报供云端 OTA 比较；NULL 表示使用 SDK 默认 `IOT_SDK_SW_VER`。详见 [OTA 升级](../guides/ota-upgrade.md) |
 
 ### `iot_client_t`（返回实例）

--- a/examples/posix/CMakeLists.txt
+++ b/examples/posix/CMakeLists.txt
@@ -108,6 +108,17 @@ add_executable(ota_demo
 target_include_directories(ota_demo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/ota-demo")
 target_link_libraries(ota_demo PRIVATE tuya_iot_client)
 
+add_executable(ota_confirm_demo
+    "${CMAKE_CURRENT_SOURCE_DIR}/ota-demo/ota_demo.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ota-confirm/ota_confirm_demo.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ota-confirm/ota_confirm_demo_main.c"
+)
+target_include_directories(ota_confirm_demo PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/ota-confirm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ota-demo"
+)
+target_link_libraries(ota_confirm_demo PRIVATE tuya_iot_client)
+
 # -- ai / rtc-client (prebuilt lib, optional) --------------------------------
 if(TARGET tuya_steam_client)
     add_executable(chat_demo

--- a/examples/posix/ota-confirm/README.md
+++ b/examples/posix/ota-confirm/README.md
@@ -1,0 +1,51 @@
+# APP-confirmed OTA demo (macOS/POSIX)
+
+This demo uses an already-activated device, so it does not run pairing or
+activation. It connects the device to MQTT with `devid`, `secret_key`, and
+`local_key`, waits for the app user to confirm the cloud OTA task, and then
+performs `tuya.device.upgrade.get` from the application thread.
+
+## Build on macOS
+
+```bash
+cmake -S examples/posix -B build/examples -DCMAKE_BUILD_TYPE=Debug
+cmake --build build/examples --target ota_confirm_demo
+```
+
+If your Mac's Perl reports an unsupported `C.UTF-8` locale during the mbedTLS
+generated-source step, build with:
+
+```bash
+LC_ALL=C LANG=C cmake --build build/examples --target ota_confirm_demo
+```
+
+## Run
+
+```bash
+export OTA_DEVID='your-device-id'
+export OTA_SECRET_KEY='your-device-secret-key'
+export OTA_LOCAL_KEY='your-device-local-key'
+export OTA_REGION='AY'   # AY, AZ, UEAZ, EU, WEAZ, IN, or SG
+
+./build/examples/ota_confirm_demo
+```
+
+The demo prints `APP-confirmed OTA notice received (channel=N)` when the cloud
+pushes MQTT protocol 15. It then queries that channel and prints the returned
+firmware metadata.
+
+To download the confirmed image, verify its cloud digest, and report
+UPGRADING/COMPLETE/ERROR:
+
+```bash
+./build/examples/ota_confirm_demo --download
+```
+
+Credentials can also be passed positionally:
+
+```bash
+./build/examples/ota_confirm_demo "$OTA_DEVID" "$OTA_SECRET_KEY" "$OTA_LOCAL_KEY" "$OTA_REGION"
+```
+
+Keep the cloud OTA task configured as APP-confirm mode. The demo never calls
+the silent-upgrade API, so the device should query only after the app confirms.

--- a/examples/posix/ota-confirm/ota_confirm_demo.c
+++ b/examples/posix/ota-confirm/ota_confirm_demo.c
@@ -1,0 +1,224 @@
+/**
+ * @file ota_confirm_demo.c
+ * @brief APP-confirmed OTA demo for an already-activated POSIX/macOS device.
+ *
+ * Flow:
+ *   1. Initialize iot_client with the activated device credentials.
+ *   2. Register ota_confirm_callback. The callback only records the channel;
+ *      it never performs an ATOP call, downloads firmware, or writes flash.
+ *   3. Connect to MQTT and wait for the app user to confirm the OTA task.
+ *   4. After the MQTT receive loop signals the main thread, call
+ *      iot_ota_check_upgrade() from this main thread.
+ *   5. With --download, fetch and verify the image locally and report status.
+ */
+
+#include "ota_demo.h"
+
+#include "iot_client.h"
+#include "iot_client_message.h"
+#include "iot_ota.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+
+#define TAG "ota_confirm_demo"
+
+typedef struct {
+    volatile sig_atomic_t received;
+    int channel;
+} ota_confirm_state_t;
+
+static volatile sig_atomic_t g_running = 1;
+
+static void on_signal(int sig)
+{
+    (void)sig;
+    g_running = 0;
+}
+
+static void on_ota_confirm(int channel, void *user_data)
+{
+    ota_confirm_state_t *state = user_data;
+    state->received = 1;
+    state->channel = channel;
+}
+
+static void on_message(const char *topic, size_t topic_len,
+                       const uint8_t *data, size_t data_len)
+{
+    printf("[%s] message: topic=%.*s (%zu bytes)\n",
+           TAG, (int)topic_len, topic, data_len);
+}
+
+static int reconnect_with_backoff(iot_client_t *client)
+{
+    static const unsigned int delays[] = {1, 2, 4, 8, 8};
+
+    for (int attempt = 1; attempt <= 5 && g_running; attempt++) {
+        printf("[%s] reconnecting (attempt %d/5)...\n", TAG, attempt);
+        if (iot_client_message_connect(client) == OPRT_OK) {
+            printf("[%s] reconnected\n", TAG);
+            return 0;
+        }
+        sleep(delays[attempt - 1]);
+    }
+    return -1;
+}
+
+static int run_confirmed_upgrade(iot_client_t *client, int channel,
+                                 int download)
+{
+    iot_ota_upgrade_info_t info = {0};
+
+    printf("[%s] application worker: checking channel %d via upgrade.get\n",
+           TAG, channel);
+    int rc = iot_ota_check_upgrade(client, channel, &info);
+    if (rc != OPRT_OK) {
+        fprintf(stderr, "[%s] iot_ota_check_upgrade failed: %d\n", TAG, rc);
+        return -1;
+    }
+
+    if (!info.has_upgrade) {
+        printf("[%s] cloud returned no pending firmware for channel %d\n",
+               TAG, channel);
+        iot_ota_upgrade_info_free(client, &info);
+        return 0;
+    }
+
+    printf("[%s] ===== confirmed firmware available =====\n", TAG);
+    printf("[%s]   version : %s\n", TAG, info.version ? info.version : "?");
+    printf("[%s]   url     : %s\n", TAG, info.url ? info.url : "?");
+    printf("[%s]   size    : %ld bytes\n", TAG, info.file_size);
+    printf("[%s]   channel : %d\n", TAG, info.channel);
+    printf("[%s]   md5     : %s\n", TAG, info.md5 ? info.md5 : "(none)");
+    printf("[%s]   hmac    : %s\n", TAG, info.hmac ? info.hmac : "(none)");
+
+    int result = 0;
+    if (download && info.url && info.url[0] != '\0') {
+        printf("[%s] reporting UPGRADING status...\n", TAG);
+        rc = iot_ota_report_status(client, info.channel, OTA_STATUS_UPGRADING);
+        if (rc != OPRT_OK) {
+            fprintf(stderr, "[%s] failed to report UPGRADING: %d\n", TAG, rc);
+        }
+
+        char out_path[256];
+        snprintf(out_path, sizeof(out_path), "firmware_%s.bin",
+                 info.version ? info.version : "unknown");
+
+        if (ota_demo_download_firmware(info.url, out_path, info.file_size) != 0 ||
+            ota_demo_verify_firmware(client, out_path, &info) != 0) {
+            fprintf(stderr, "[%s] firmware download/verify failed\n", TAG);
+            printf("[%s] reporting ERROR status...\n", TAG);
+            iot_ota_report_status(client, info.channel, OTA_STATUS_ERROR);
+            result = -1;
+        } else {
+            printf("[%s] reporting COMPLETE status...\n", TAG);
+            rc = iot_ota_report_status(client, info.channel, OTA_STATUS_COMPLETE);
+            if (rc != OPRT_OK) {
+                fprintf(stderr, "[%s] failed to report COMPLETE: %d\n", TAG, rc);
+            }
+        }
+    } else {
+        printf("[%s] query-only mode: no status reported\n", TAG);
+    }
+
+    iot_ota_upgrade_info_free(client, &info);
+    return result;
+}
+
+int demo_ota_confirm_run(const char *devid, const char *secret_key,
+                         const char *local_key, const char *region_name,
+                         int download)
+{
+    iot_region_t region = AY;
+    if (strcmp(region_name, "AZ") == 0) {
+        region = AZ;
+    } else if (strcmp(region_name, "UEAZ") == 0) {
+        region = UEAZ;
+    } else if (strcmp(region_name, "EU") == 0) {
+        region = EU;
+    } else if (strcmp(region_name, "WEAZ") == 0) {
+        region = WEAZ;
+    } else if (strcmp(region_name, "IN") == 0) {
+        region = IN;
+    } else if (strcmp(region_name, "SG") == 0) {
+        region = SG;
+    } else if (strcmp(region_name, "AY") != 0) {
+        fprintf(stderr, "[%s] unsupported region '%s'\n", TAG, region_name);
+        return 1;
+    }
+
+    if (iot_init_default() != OPRT_OK) {
+        fprintf(stderr, "[%s] iot_init_default failed\n", TAG);
+        return 1;
+    }
+    log_set_level(LOG_INFO);
+    signal(SIGINT, on_signal);
+    signal(SIGTERM, on_signal);
+
+    ota_confirm_state_t state = {0};
+
+    iot_client_config_t cfg = {
+        .region               = region,
+        .env                  = PROD,
+        .mqtt_disable_tls     = false,
+        .mqtt_auto_connect    = false,
+        .message_callback     = on_message,
+        .ota_confirm_callback = on_ota_confirm,
+        .ota_confirm_user_data = &state,
+        .sw_ver               = "1.0.0",
+    };
+    strncpy(cfg.devid, devid, sizeof(cfg.devid) - 1);
+    strncpy(cfg.secret_key, secret_key, sizeof(cfg.secret_key) - 1);
+    strncpy(cfg.local_key, local_key, sizeof(cfg.local_key) - 1);
+
+    iot_client_t *client = iot_client_init(&cfg);
+    if (!client) {
+        fprintf(stderr, "[%s] iot_client_init failed\n", TAG);
+        return 1;
+    }
+
+    printf("[%s] client initialized (devid=%s, region=%s)\n",
+           TAG, client->devid, region_name);
+    int rc = iot_client_message_connect(client);
+    if (rc != OPRT_OK) {
+        fprintf(stderr, "[%s] MQTT connect failed: %d\n", TAG, rc);
+        iot_client_deinit(client);
+        return 1;
+    }
+
+    printf("[%s] MQTT connected; waiting for APP OTA confirmation\n", TAG);
+    printf("[%s] confirm the upgrade in the app (Ctrl-C cancels)\n\n", TAG);
+
+    int result = 0;
+    while (g_running && !state.received) {
+        rc = iot_client_process(client, 200);
+        if (rc != OPRT_OK) {
+            fprintf(stderr, "[%s] MQTT process failed: %d\n", TAG, rc);
+            iot_client_message_disconnect(client);
+            if (reconnect_with_backoff(client) != 0) {
+                fprintf(stderr, "[%s] give up after reconnect failures\n", TAG);
+                result = 1;
+                goto out;
+            }
+        }
+    }
+
+    if (state.received) {
+        printf("\n[%s] ** APP-confirmed OTA notice received (channel=%d) **\n",
+               TAG, state.channel);
+        if (run_confirmed_upgrade(client, state.channel, download) != 0) {
+            result = 1;
+        }
+    } else {
+        printf("\n[%s] cancelled before APP confirmation\n", TAG);
+    }
+
+out:
+    iot_client_message_disconnect(client);
+    iot_client_deinit(client);
+    return result;
+}

--- a/examples/posix/ota-confirm/ota_confirm_demo_main.c
+++ b/examples/posix/ota-confirm/ota_confirm_demo_main.c
@@ -1,0 +1,100 @@
+/**
+ * @file ota_confirm_demo_main.c
+ * @brief Entry point for the APP-confirmed POSIX/macOS OTA demo.
+ *
+ * Credentials can be supplied as arguments or through environment variables:
+ *   OTA_DEVID, OTA_SECRET_KEY, OTA_LOCAL_KEY, OTA_REGION
+ *
+ * Usage:
+ *   ./ota_confirm_demo [devid secret_key local_key [region]] [--download]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ota_demo.h"
+
+static void usage(const char *prog)
+{
+    fprintf(stderr,
+        "Usage: [OTA_DEVID=x] [OTA_SECRET_KEY=x] [OTA_LOCAL_KEY=x] "
+        "[OTA_REGION=AY] %s [devid secret_key local_key [region]] [--download]\n"
+        "\n"
+        "Arguments:\n"
+        "  devid       Already-activated device ID\n"
+        "  secret_key  Device secret key\n"
+        "  local_key   Device local key\n"
+        "  region      AY, AZ, UEAZ, EU, WEAZ, IN, SG (default: OTA_REGION or AY)\n"
+        "  --download  Download and verify the confirmed image locally\n"
+        "\n"
+        "Environment variables are useful for avoiding sensitive values in the\n"
+        "shell history. Query-only mode does not report OTA status.\n",
+        prog);
+}
+
+static const char *credential(const char *arg, const char *name)
+{
+    if (arg && arg[0] != '\0') return arg;
+    return getenv(name);
+}
+
+int main(int argc, char *argv[])
+{
+    const char *devid = NULL;
+    const char *secret_key = NULL;
+    const char *local_key = NULL;
+    const char *region = getenv("OTA_REGION");
+    int positional = 0;
+    int download = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--download") == 0) {
+            download = 1;
+        } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            usage(argv[0]);
+            return 0;
+        } else if (argv[i][0] == '-') {
+            fprintf(stderr, "Unknown option: %s\n\n", argv[i]);
+            usage(argv[0]);
+            return 1;
+        } else if (positional == 0) {
+            devid = argv[i];
+            positional++;
+        } else if (positional == 1) {
+            secret_key = argv[i];
+            positional++;
+        } else if (positional == 2) {
+            local_key = argv[i];
+            positional++;
+        } else if (positional == 3) {
+            region = argv[i];
+            positional++;
+        } else {
+            fprintf(stderr, "Too many arguments\n\n");
+            usage(argv[0]);
+            return 1;
+        }
+    }
+
+    devid = credential(devid, "OTA_DEVID");
+    secret_key = credential(secret_key, "OTA_SECRET_KEY");
+    local_key = credential(local_key, "OTA_LOCAL_KEY");
+    if (region == NULL || region[0] == '\0') region = "AY";
+
+    if (!devid || !secret_key || !local_key) {
+        fprintf(stderr,
+                "Missing credentials: provide arguments or set "
+                "OTA_DEVID, OTA_SECRET_KEY, and OTA_LOCAL_KEY.\n\n");
+        usage(argv[0]);
+        return 1;
+    }
+
+    printf("=== APP-confirmed OTA demo ===\n");
+    printf("devid    : %s\n", devid);
+    printf("region   : %s\n", region);
+    printf("download : %s\n\n", download ? "yes" : "no");
+
+    int ret = demo_ota_confirm_run(devid, secret_key, local_key, region, download);
+    return ret == 0 ? 0 : 1;
+}

--- a/examples/posix/ota-demo/ota_demo.c
+++ b/examples/posix/ota-demo/ota_demo.c
@@ -27,14 +27,6 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-/* Minimal HTTP client for downloading the firmware image.
- * The SDK's http_client_interface is designed for small JSON ATOP responses
- * (fixed buffer), so for the firmware binary we use libcurl via popen, or
- * more simply, just report the URL and let the caller decide.
- *
- * For this POSIX demo, we download using the standard C library + OpenSSL
- * is overkill; instead we shell out to curl(1) which is universally available
- * on dev machines. */
 #include <sys/wait.h>
 
 #define TAG "ota_demo"
@@ -43,8 +35,8 @@
 /* Firmware download (simulated — writes to a local file)                  */
 /* ----------------------------------------------------------------------- */
 
-static int verify_firmware(iot_client_t *client, const char *path,
-                           const iot_ota_upgrade_info_t *info)
+int ota_demo_verify_firmware(iot_client_t *client, const char *path,
+                             const iot_ota_upgrade_info_t *info)
 {
     iot_ota_verify_ctx_t *ctx = NULL;
     int rc = iot_ota_verify_init(client, info, &ctx);
@@ -93,15 +85,20 @@ static int verify_firmware(iot_client_t *client, const char *path,
     return -1;
 }
 
-static int download_firmware(const char *url, const char *out_path,
-                             long expected_size)
+int ota_demo_download_firmware(const char *url, const char *out_path,
+                               long expected_size)
 {
     printf("[%s] downloading %s -> %s\n", TAG, url, out_path);
 
-    /* Use curl(1) for simplicity in this POSIX demo.
-     * A real device uses the platform HTTP client + flash-write API. */
+    /* Use curl(1) for simplicity in this POSIX demo. A real device uses its
+     * platform HTTP client and flash-write API. */
     char cmd[2048];
-    snprintf(cmd, sizeof(cmd), "curl -sSL -o '%s' '%s'", out_path, url);
+    int sn = snprintf(cmd, sizeof(cmd), "curl -sSL --fail -o '%s' '%s'",
+                      out_path, url);
+    if (sn < 0 || (size_t)sn >= sizeof(cmd)) {
+        fprintf(stderr, "[%s] firmware URL is too long for the demo buffer\n", TAG);
+        return -1;
+    }
 
     int rc = system(cmd);
     if (rc != 0) {
@@ -109,7 +106,6 @@ static int download_firmware(const char *url, const char *out_path,
         return -1;
     }
 
-    /* Verify the downloaded file size */
     struct stat st;
     if (stat(out_path, &st) != 0) {
         fprintf(stderr, "[%s] cannot stat %s\n", TAG, out_path);
@@ -117,7 +113,6 @@ static int download_firmware(const char *url, const char *out_path,
     }
 
     printf("[%s] downloaded %lld bytes\n", TAG, (long long)st.st_size);
-
     if (expected_size > 0 && (long)st.st_size != expected_size) {
         fprintf(stderr, "[%s] size mismatch: got %lld, expected %ld\n",
                 TAG, (long long)st.st_size, expected_size);
@@ -202,8 +197,8 @@ int demo_ota_run(const char *devid, const char *secret_key, const char *local_ke
         snprintf(out_path, sizeof(out_path), "firmware_%s.bin",
                  info.version ? info.version : "unknown");
 
-        if (download_firmware(info.url, out_path, info.file_size) != 0 ||
-            verify_firmware(client, out_path, &info) != 0) {
+        if (ota_demo_download_firmware(info.url, out_path, info.file_size) != 0 ||
+            ota_demo_verify_firmware(client, out_path, &info) != 0) {
             fprintf(stderr, "[%s] firmware download/verify failed\n", TAG);
             printf("[%s] reporting FAILURE status...\n", TAG);
             iot_ota_report_status(client, info.channel, OTA_STATUS_ERROR);

--- a/examples/posix/ota-demo/ota_demo.h
+++ b/examples/posix/ota-demo/ota_demo.h
@@ -1,7 +1,20 @@
 #ifndef OTA_DEMO_H
 #define OTA_DEMO_H
 
+#include "iot_client.h"
+#include "iot_ota.h"
+
 int demo_ota_run(const char *devid, const char *secret_key, const char *local_key,
                  const char *sw_ver, int auto_download);
+
+int demo_ota_confirm_run(const char *devid, const char *secret_key,
+                         const char *local_key, const char *region_name,
+                         int download);
+
+int ota_demo_verify_firmware(iot_client_t *client, const char *path,
+                             const iot_ota_upgrade_info_t *info);
+
+int ota_demo_download_firmware(const char *url, const char *out_path,
+                               long expected_size);
 
 #endif /* OTA_DEMO_H */

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -117,6 +117,25 @@ typedef enum {
 typedef void (*iot_reset_callback_t)(iot_reset_type_t type, void *user_data);
 
 /**
+ * @brief Callback fired when the cloud confirms an OTA upgrade from the app.
+ *
+ * Fired on the iot_client_process() thread, exactly like message_callback.
+ * This means the app user has confirmed the upgrade and the cloud has notified
+ * the device over MQTT protocol 15. Keep this callback non-blocking: set a
+ * flag, signal a semaphore, or enqueue work for an application worker. Do not
+ * call iot_ota_check_upgrade(), download firmware, or write flash here — those
+ * operations must run outside the MQTT process loop.
+ *
+ * Registering this callback opts the client in to consuming protocol-15
+ * notices: they then never reach the DP layer or the raw message_callback.
+ * Without it they stay on the message_callback path for compatibility.
+ *
+ * @param channel   Firmware channel from data.firmwareType (0 = main MCU).
+ * @param user_data The ota_confirm_user_data pointer registered with the config.
+ */
+typedef void (*iot_ota_confirm_callback_t)(int channel, void *user_data);
+
+/**
  * @brief IoT client configuration structure
  */
 typedef struct {
@@ -132,6 +151,8 @@ typedef struct {
     iot_message_callback_t message_callback; // MQTT message callback
     iot_reset_callback_t reset_callback;     // Cloud device-remove (protocol 11) callback
     void *reset_user_data;                   // Opaque pointer passed back to reset_callback
+    iot_ota_confirm_callback_t ota_confirm_callback; // APP-confirmed OTA (protocol 15) callback
+    void *ota_confirm_user_data;                      // Opaque pointer passed back to ota_confirm_callback
 
     /* ---- DP layer restore (all caller-owned, may be NULL) ---- */
     const char *schema;            // Persisted DP schema JSON to restore on restart (NULL = none / loose mode)
@@ -160,6 +181,8 @@ typedef struct {
     iot_message_callback_t message_callback; // MQTT message callback
     iot_reset_callback_t reset_callback;     // Cloud device-remove (protocol 11) callback
     void *reset_user_data;                   // Opaque pointer passed back to reset_callback
+    iot_ota_confirm_callback_t ota_confirm_callback; // APP-confirmed OTA (protocol 15) callback
+    void *ota_confirm_user_data;                      // Opaque pointer passed back to ota_confirm_callback
     const char *sw_ver;            // Application firmware version (e.g. "1.2.3"); NULL = use SDK default IOT_SDK_SW_VER
 } iot_on_boarding_config_t;
 
@@ -197,6 +220,8 @@ struct iot_dp_context;
     iot_message_callback_t message_callback;  // User callback for incoming messages
     iot_reset_callback_t reset_callback;      // Cloud device-remove (protocol 11) callback
     void *reset_user_data;                    // Opaque pointer passed back to reset_callback
+    iot_ota_confirm_callback_t ota_confirm_callback; // APP-confirmed OTA (protocol 15) callback
+    void *ota_confirm_user_data;                      // Opaque pointer passed back to ota_confirm_callback
 
     struct iot_dp_context *dp;    // DP layer state; points into dp_storage, NULL when inactive
     void *dp_storage[IOT_DP_CONTEXT_STORAGE / sizeof(void *)]; // inline storage for *dp (no heap)

--- a/modules/iot-client/src/iot_client.c
+++ b/modules/iot-client/src/iot_client.c
@@ -216,6 +216,8 @@ IOT_API iot_client_t *iot_client_init(const iot_client_config_t *config)
     client->message_callback = config->message_callback;
     client->reset_callback = config->reset_callback;
     client->reset_user_data = config->reset_user_data;
+    client->ota_confirm_callback = config->ota_confirm_callback;
+    client->ota_confirm_user_data = config->ota_confirm_user_data;
 
     /* DP layer: restore persisted schema_id / schema from config (restart path).
      * On-boarding paths leave these NULL here and set them after activation. */
@@ -373,6 +375,8 @@ IOT_API iot_client_t *iot_client_init_on_boarding(const iot_on_boarding_config_t
     client_config.message_callback = config->message_callback;
     client_config.reset_callback = config->reset_callback;
     client_config.reset_user_data = config->reset_user_data;
+    client_config.ota_confirm_callback = config->ota_confirm_callback;
+    client_config.ota_confirm_user_data = config->ota_confirm_user_data;
     client_config.sw_ver = sw_ver;
     /* schema / schema_id come from the activation response. iot_client_init()
      * copies them and rebuilds the DP registry from the schema (dp_state is then
@@ -467,6 +471,8 @@ IOT_API iot_client_t *iot_client_init_on_boarding_with_token(const iot_on_boardi
     client_config.message_callback = config->message_callback;
     client_config.reset_callback = config->reset_callback;
     client_config.reset_user_data = config->reset_user_data;
+    client_config.ota_confirm_callback = config->ota_confirm_callback;
+    client_config.ota_confirm_user_data = config->ota_confirm_user_data;
     client_config.sw_ver = sw_ver;
     /* schema / schema_id come from the activation response. iot_client_init()
      * copies them and rebuilds the DP registry from the schema (dp_state is then

--- a/modules/iot-client/src/iot_client_message.c
+++ b/modules/iot-client/src/iot_client_message.c
@@ -31,6 +31,8 @@ static void mqtt_message_handler(const char *topic, size_t topic_len,
          * leak into the DP layer or raw message callback. */
         if (iot_client_message_handle_reset(client, decrypted, decrypted_len)) {
             /* consumed: reset notices never reach the DP layer or raw callback */
+        } else if (iot_client_message_handle_ota_confirm(client, decrypted, decrypted_len)) {
+            /* consumed: APP-confirmed OTA notices never reach the DP/raw path */
         } else if (!iot_dp_dispatch_downlink(client, topic, topic_len, decrypted, decrypted_len)
             && client->message_callback) {
             client->message_callback(topic, topic_len, decrypted, decrypted_len);
@@ -96,6 +98,44 @@ bool iot_client_message_handle_reset(iot_client_t *client,
              type == IOT_RESET_REMOTE_FACTORY ? "factory" : "unbind");
 
     client->reset_callback(type, client->reset_user_data);
+
+    cJSON_Delete(root);
+    return true;
+}
+
+bool iot_client_message_handle_ota_confirm(iot_client_t *client,
+                                            const uint8_t *bytes, size_t len)
+{
+    if (!client || !bytes || len == 0) return false;
+
+    cJSON *root = cJSON_ParseWithLength((const char *)bytes, len);
+    if (!root) return false;
+
+    cJSON *jproto = cJSON_GetObjectItem(root, "protocol");
+    if (!cJSON_IsNumber(jproto) || jproto->valueint != IOT_PROTO_UPGRADE_REQUEST) {
+        cJSON_Delete(root);
+        return false;
+    }
+
+    /* Not opted in: preserve the pre-callback behavior and expose protocol 15
+     * to the raw message_callback for applications that parse it themselves. */
+    if (!client->ota_confirm_callback) {
+        cJSON_Delete(root);
+        return false;
+    }
+
+    /* TuyaOpen treats a missing firmwareType as the main firmware channel.
+     * A malformed value follows the same default rather than rejecting an
+     * otherwise-authenticated cloud notice. */
+    int channel = 0;
+    cJSON *data = cJSON_GetObjectItem(root, "data");
+    cJSON *jchannel = data ? cJSON_GetObjectItem(data, "firmwareType") : NULL;
+    if (cJSON_IsNumber(jchannel)) {
+        channel = jchannel->valueint;
+    }
+
+    log_info("ota confirm: app-confirmed upgrade notice received (channel=%d)", channel);
+    client->ota_confirm_callback(channel, client->ota_confirm_user_data);
 
     cJSON_Delete(root);
     return true;

--- a/modules/iot-client/src/iot_client_message.h
+++ b/modules/iot-client/src/iot_client_message.h
@@ -7,6 +7,7 @@
  * Src-private on purpose, like DP_PROTO_* in iot_dp.c: the wire number is an
  * implementation detail; apps only see iot_reset_type_t. */
 #define IOT_PROTO_GW_RESET 11  /* cloud → device: device removed / factory reset */
+#define IOT_PROTO_UPGRADE_REQUEST 15  /* cloud → device: app confirmed an OTA upgrade */
 
 /**
  * @brief Connect to the MQTT broker and subscribe to the device's inbound topic.
@@ -74,5 +75,24 @@ int iot_client_message_publish(iot_client_t *client,
  */
 bool iot_client_message_handle_reset(iot_client_t *client,
                                      const uint8_t *bytes, size_t len);
+
+/**
+ * @brief Check if a decrypted MQTT payload is an APP-confirmed OTA notice
+ *        (protocol 15) and fire the OTA confirm callback if so.
+ *
+ * Parses data.firmwareType as the firmware channel; a missing or malformed
+ * value defaults to channel 0, mirroring TuyaOpen's app-triggered OTA flow.
+ * Consumption is opt-in: with an ota_confirm_callback registered, protocol-15
+ * envelopes are consumed and never reach the DP layer or raw message callback;
+ * without one they pass through as previous versions did.
+ *
+ * @param client IoT client (ota_confirm_callback NULL = passthrough)
+ * @param bytes  Decrypted payload bytes
+ * @param len    Length of payload
+ * @return true if the message was a protocol-15 OTA notice and an
+ *         ota_confirm_callback is registered (consumed), false otherwise
+ */
+bool iot_client_message_handle_ota_confirm(iot_client_t *client,
+                                            const uint8_t *bytes, size_t len);
 
 #endif /* __IOT_CLIENT_MESSAGE_H__ */

--- a/modules/iot-client/test/iot_client_message_test.c
+++ b/modules/iot-client/test/iot_client_message_test.c
@@ -96,6 +96,24 @@ static void test_message_callback(const char *topic, size_t topic_len,
            cb_topic, cb_data_len, (int)cb_data_len, cb_data);
 }
 
+static volatile int ota_confirm_cb_called = 0;
+static int ota_confirm_cb_channel = -1;
+static void *ota_confirm_cb_user_data = NULL;
+
+static void test_ota_confirm_callback(int channel, void *user_data)
+{
+    ota_confirm_cb_called++;
+    ota_confirm_cb_channel = channel;
+    ota_confirm_cb_user_data = user_data;
+}
+
+static void reset_ota_confirm_callback_state(void)
+{
+    ota_confirm_cb_called = 0;
+    ota_confirm_cb_channel = -1;
+    ota_confirm_cb_user_data = NULL;
+}
+
 static int wait_for_port(int port)
 {
     for (int i = 0; i < 50; i++) {
@@ -476,6 +494,33 @@ static int test_iot_client_init_no_autoconnect(void)
     return result;
 }
 
+/* [7] init copies the APP-confirmed OTA callback and its user data */
+static int test_iot_client_init_copies_ota_confirm_config(void)
+{
+    static char user_data;
+    iot_client_config_t cfg = {0};
+    cfg.ota_confirm_callback = test_ota_confirm_callback;
+    cfg.ota_confirm_user_data = &user_data;
+
+    iot_client_t *client = iot_client_init(&cfg);
+    if (!client) {
+        printf("  iot_client_init returned NULL\n");
+        return -1;
+    }
+
+    int result = 0;
+    if (client->ota_confirm_callback != test_ota_confirm_callback) {
+        printf("  ota_confirm_callback was not copied\n");
+        result = -1;
+    }
+    if (client->ota_confirm_user_data != &user_data) {
+        printf("  ota_confirm_user_data was not copied\n");
+        result = -1;
+    }
+    iot_client_deinit(client);
+    return result;
+}
+
 /* ---------- Reset callback tests (network-free, plaintext input) ---------- */
 
 static volatile int reset_cb_called = 0;
@@ -619,6 +664,115 @@ out:
     return rc;
 }
 
+/* ---------- APP-confirmed OTA callback tests (network-free, plaintext) ---------- */
+
+static int test_ota_confirm_channel_from_firmware_type(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
+    int rc = -1;
+    static char user_data;
+    reset_ota_confirm_callback_state();
+    c->ota_confirm_callback = test_ota_confirm_callback;
+    c->ota_confirm_user_data = &user_data;
+
+    const char *json = "{\"protocol\":15,\"t\":1700000000,\"data\":{\"firmwareType\":5}}";
+    if (!iot_client_message_handle_ota_confirm(c, (const uint8_t *)json, strlen(json))) {
+        printf("  protocol 15 not consumed\n"); goto out;
+    }
+    if (ota_confirm_cb_called != 1) {
+        printf("  callback not fired (%d)\n", ota_confirm_cb_called); goto out;
+    }
+    if (ota_confirm_cb_channel != 5) {
+        printf("  expected channel 5, got %d\n", ota_confirm_cb_channel); goto out;
+    }
+    if (ota_confirm_cb_user_data != &user_data) {
+        printf("  callback user_data mismatch\n"); goto out;
+    }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
+static int test_ota_confirm_missing_or_invalid_firmware_type_defaults_to_main(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
+    int rc = -1;
+    reset_ota_confirm_callback_state();
+    c->ota_confirm_callback = test_ota_confirm_callback;
+
+    const char *json = "{\"protocol\":15,\"t\":1700000000}";
+    if (!iot_client_message_handle_ota_confirm(c, (const uint8_t *)json, strlen(json))) {
+        printf("  protocol 15 without firmwareType not consumed\n"); goto out;
+    }
+    if (ota_confirm_cb_called != 1 || ota_confirm_cb_channel != 0) {
+        printf("  callback result: called=%d channel=%d (expected 1/0)\n",
+               ota_confirm_cb_called, ota_confirm_cb_channel); goto out;
+    }
+
+    reset_ota_confirm_callback_state();
+    const char *invalid_type_json = "{\"protocol\":15,\"data\":{\"firmwareType\":\"5\"}}";
+    if (!iot_client_message_handle_ota_confirm(c, (const uint8_t *)invalid_type_json, strlen(invalid_type_json))) {
+        printf("  protocol 15 with malformed firmwareType not consumed\n"); goto out;
+    }
+    if (ota_confirm_cb_called != 1 || ota_confirm_cb_channel != 0) {
+        printf("  malformed firmwareType result: called=%d channel=%d (expected 1/0)\n",
+               ota_confirm_cb_called, ota_confirm_cb_channel); goto out;
+    }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
+static int test_ota_confirm_no_callback_passthrough(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
+    int rc = -1;
+    reset_ota_confirm_callback_state();
+
+    const char *json = "{\"protocol\":15,\"data\":{\"firmwareType\":5}}";
+    if (iot_client_message_handle_ota_confirm(c, (const uint8_t *)json, strlen(json))) {
+        printf("  protocol 15 consumed without a registered callback\n"); goto out;
+    }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
+static int test_ota_confirm_non_matching_payloads_passthrough(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *c = make_bare_client(pal, TEST_DEVID);
+    if (!c) { printf("  alloc failed\n"); return -1; }
+    int rc = -1;
+    reset_ota_confirm_callback_state();
+    c->ota_confirm_callback = test_ota_confirm_callback;
+
+    static const char dp_json[] = "{\"protocol\":5,\"data\":{\"dps\":{\"1\":true}}}";
+    static const char no_proto_json[] = "{\"data\":{\"firmwareType\":5}}";
+    static const char garbage[] = "not json";
+    if (iot_client_message_handle_ota_confirm(c, (const uint8_t *)dp_json, sizeof(dp_json) - 1) ||
+        iot_client_message_handle_ota_confirm(c, (const uint8_t *)no_proto_json, sizeof(no_proto_json) - 1) ||
+        iot_client_message_handle_ota_confirm(c, (const uint8_t *)garbage, sizeof(garbage) - 1)) {
+        printf("  a non-protocol-15 payload was consumed\n"); goto out;
+    }
+    if (ota_confirm_cb_called != 0) {
+        printf("  callback fired on passthrough (%d)\n", ota_confirm_cb_called); goto out;
+    }
+    rc = 0;
+out:
+    pal->free(c);
+    return rc;
+}
+
 /* ---------- main ---------- */
 
 int main(void)
@@ -663,6 +817,7 @@ int main(void)
     /* iot_client_init + mqtt_auto_connect (no mocks needed: empty devid skips DNS) */
     RUN_TEST(test_iot_client_init_autoconnect_no_url);
     RUN_TEST(test_iot_client_init_no_autoconnect);
+    RUN_TEST(test_iot_client_init_copies_ota_confirm_config);
 
     /* Reset callback tests (network-free, no mocks needed) */
     RUN_TEST(test_reset_unbind);
@@ -670,6 +825,12 @@ int main(void)
     RUN_TEST(test_reset_foreign_gwid);
     RUN_TEST(test_reset_passthrough);
     RUN_TEST(test_reset_no_callback_passthrough);
+
+    /* APP-confirmed OTA callback tests (network-free, no mocks needed) */
+    RUN_TEST(test_ota_confirm_channel_from_firmware_type);
+    RUN_TEST(test_ota_confirm_missing_or_invalid_firmware_type_defaults_to_main);
+    RUN_TEST(test_ota_confirm_no_callback_passthrough);
+    RUN_TEST(test_ota_confirm_non_matching_payloads_passthrough);
 
     stop_mock_wrongkey();
     stop_mock_invalid();


### PR DESCRIPTION
## Summary
- Parse MQTT protocol 15 as an APP-confirmed OTA notice and expose a lightweight `ota_confirm_callback` to applications
- Copy the callback config through direct initialization and both onboarding paths
- Consume protocol 15 only when the callback is registered; otherwise preserve raw-message compatibility
- Add a POSIX/macOS demo that uses activated credentials, waits for APP confirmation, then calls `iot_ota_check_upgrade()`
- Do not add silent-upgrade scheduling; the SDK only reports the confirmation and the application performs OTA work

## Testing
- `cmake --build build --target iot_message_test iot_ota_verify_test iot_ota_test`
- New protocol-15 callback/config unit tests pass (target name is `iot_message_test`)
- `iot_ota_verify_test` passes
- `iot_ota_test` compiles; runtime mock requires local `pycryptodome`, which was unavailable
- Existing MQTT/TLS mock CONNECT failures remain unrelated and reproducible before this change
- Built and ran `examples/posix/ota-confirm/ota_confirm_demo` on macOS against a cloud task configured for APP confirmation; received channel 0 and successfully fetched firmware metadata via `upgrade.get`
