### PR TITLE
fix(iot): make the ATOP response buffer sizable, and name the real failure

### DIFF
--- a/modules/iot-client/src/http_client_interface.c
+++ b/modules/iot-client/src/http_client_interface.c
@@ -223,8 +223,20 @@ http_client_status_t http_client_request(const http_client_request_t *request,
 
     // One block holds both the request-header and response buffers (both alive
     // through HTTPClient_Send) -- one allocation instead of two.
+    /* Both are overridable at build time (-D...) because the right size is a
+     * property of the PRODUCT, not of the SDK: an ATOP activation response
+     * carries the device's DP schema, so a product with a moderately large
+     * schema overflows any fixed default. Observed on a Tuya alarm-clock
+     * product: contentLength 6558 with a 4096 buffer -> HTTPInsufficientMemory,
+     * even though the server had returned 200 and the activation had SUCCEEDED
+     * on its side. The buffer is taken from the PAL allocator, so raising it
+     * lands in PSRAM on targets that route large allocations there. */
+    #ifndef REQUEST_HEADER_BUFFER_SIZE
     #define REQUEST_HEADER_BUFFER_SIZE 1024
+    #endif
+    #ifndef RESPONSE_BUFFER_SIZE
     #define RESPONSE_BUFFER_SIZE 4096
+    #endif
     uint8_t *http_buf = (uint8_t *)pal->malloc(REQUEST_HEADER_BUFFER_SIZE + RESPONSE_BUFFER_SIZE);
     if (!http_buf) {
         log_error("Failed to allocate HTTP buffers");
@@ -331,7 +343,22 @@ http_client_status_t http_client_request(const http_client_request_t *request,
         log_debug("HTTP request successful: status=%d, body_len=%d",
                  response->status_code, (int)response->body_length);
     } else {
-        log_error("HTTP request failed: %d", http_status);
+        /* Name the actual cause. HTTPInsufficientMemory used to surface to the
+         * caller as a generic "Communication error", which sends people hunting
+         * the network for what is really a too-small buffer — and the request
+         * may well have SUCCEEDED on the server (HTTP 200) before we ran out of
+         * room to read the reply. */
+        if (http_status == HTTPInsufficientMemory) {
+            log_error("HTTP response does not fit: need %u B body + %u B headers, "
+                      "buffer is %d B (server said %u). Rebuild with a larger "
+                      "-DRESPONSE_BUFFER_SIZE.",
+                      (unsigned)http_response.contentLength,
+                      (unsigned)http_response.headersLen,
+                      RESPONSE_BUFFER_SIZE,
+                      (unsigned)http_response.statusCode);
+        } else {
+            log_error("HTTP request failed: %d", http_status);
+        }
 
         // Map coreHTTP status to our status
         switch (http_status) {


### PR DESCRIPTION
## 问题

激活（`on_boarding_with_token`）在某些产品上必然失败，而报出来的原因是错的。

真实案例：一个闹钟品类的产品，PID 换过去之后激活一直失败，日志是这样：

```
[I] [iot] Sending activation request with:
[E] [iot] HTTP request failed: 5
[E] [iot] http_request_send error:-1
[E] [iot] atop_base_request error:-1
[E] [iot] ✗ Activation request failed with error code: -1
[E] [iot]   - Communication error
```

"Communication error" 把人引去查网络、路由器、DNS、证书 —— 全是错的方向。
加一行探针把 coreHTTP 的返回值打全之后，真相是：

```
HTTP request failed: 5 (respbuf=4096 used_hdr=104 body=3971 contentLen=6558 hdrsDone=1 status=200)
```

- `5` = `HTTPInsufficientMemory`，**不是网络错误**
- `status=200` —— **服务端已经接受了激活，设备侧其实已经激活成功**
- `contentLen=6558` vs `RESPONSE_BUFFER_SIZE` 硬编码的 `4096`

ATOP 的激活响应里带着设备的 DP schema，**它的大小是"产品"的属性，不是 SDK 的属性**。
DP 稍多的产品就会超过 4096，然后卡在"设备读不完服务端已经成功返回的响应"上。

## 改动

`modules/iot-client/src/http_client_interface.c`，两处，**默认尺寸下行为完全不变**：

1. **`REQUEST_HEADER_BUFFER_SIZE` / `RESPONSE_BUFFER_SIZE` 用 `#ifndef` 守卫**，
   让应用在构建时用 `-D` 自行设定。和 `TAI_FRAG_BUF_SIZE` 是同一个套路。
   缓冲走 PAL 分配器，所以在把大块分配路由到 PSRAM 的平台上，调大不占内部 RAM。

2. **`HTTPInsufficientMemory` 单独报错，说清是什么**：需要多少、缓冲多大、
   服务端返回了什么状态码，并直接指出改哪个 `-D`：

```
HTTP response does not fit: need 6558 B body + 104 B headers,
buffer is 4096 B (server said 200). Rebuild with a larger -DRESPONSE_BUFFER_SIZE.
```

## 验证

- 业务侧加 `-DRESPONSE_BUFFER_SIZE=16384` 后，同一产品激活一次通过，
  后续 MQTT / AI 会话 / 设备侧 MCP 全链路正常。
- 不加 `-D` 时宏值与原来一致（4096 / 1024），既有工程零影响。
