### PR TITLE
feat(iot-client): name the reason a broker refused, instead of a bare…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,13 @@ ctest --test-dir build --output-on-failure --no-tests=error --timeout 180   # ne
   to it is verifiable offline. The root CMakeLists declares `tuya_steam_client` only when the
   current platform's `libstm.a` exists (its if/elseif chain covers three of the five
   architectures on disk).
-- **The vendored libraries are built with their custom-config hooks disabled**
-  (`MQTT_DO_NOT_USE_CUSTOM_CONFIG`, `HTTP_DO_NOT_USE_CUSTOM_CONFIG`), so coreMQTT's thread-safety
-  hooks and coreHTTP's own error logging expand to nothing — expect no diagnostics from either.
+- **coreHTTP is built with its custom-config hook disabled** (`HTTP_DO_NOT_USE_CUSTOM_CONFIG`),
+  so its own error logging expands to nothing — expect no diagnostics from it. coreMQTT is the
+  exception and must stay that way: it picks up `common/core_mqtt_config.h`, which routes its
+  Error/Warn into the log facade so a broker's refusal reason survives (`Connection refused: bad
+  user name or password.`); without it a rejected CONNECT is a bare `MQTTServerRefused`. Both
+  build paths matter — the root `CMakeLists.txt` **and** `examples/esp-idf/components/agentic_kit`,
+  which had to be fixed separately. coreMQTT's thread-safety hooks are still unset.
 
 ## Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- common — coreMQTT's Error/Warn logs are routed into the SDK log facade
+  (`common/core_mqtt_config.h`), so a broker's actual refusal reason is visible.
+  - coreMQTT was built with `MQTT_DO_NOT_USE_CUSTOM_CONFIG`, leaving its `Log*`
+    macros expanding to nothing. A refused CONNECT therefore reached the log as
+    a bare `MQTT_Connect failed: 6` — `MQTTServerRefused` — while coreMQTT knew
+    and discarded which of the five MQTT 3.1.1 reasons the broker sent.
+    `logConnackResponse()` had the answer and logged it into a void.
+  - The same connect now also prints `Connection refused: bad user name or
+    password.` (or `identifier rejected` / `not authorized` / …), plus the
+    SUBSCRIBE refusals that were equally invisible. Pinned by a new
+    `test_connack_reason_is_logged`, which captures the log facade and asserts
+    the broker's words arrive: the pre-existing `test_connect_auth_fail` drives
+    the same refusal but asserts only the return code, so it passes with the
+    routing disabled and cannot protect it.
+  - Wired in both build paths. `examples/esp-idf/components/agentic_kit` sets
+    its own compile definitions, so the ESP-IDF component kept the feature
+    switched off — on precisely the embedded target the diagnostic exists for —
+    until it was fixed too.
+  - `core_mqtt` now declares its dependency on `agentic_kit_common`. Its objects
+    reference `log_emit()`, and the link previously resolved only because
+    another archive was scanned first and happened to pull `log.o` in.
+  - Only Error and Warn are routed. `LogInfo`/`LogDebug` fire per packet, so
+    wiring them would cost flash and bury the useful lines; they stay compiled
+    out, which keeps this a diagnostics-only change with no behavioural or
+    hot-path effect.
+  - The SDK's own `mqtt.c` log lines that printed a bare `MQTTStatus_t` (all
+    seven: Init, InitStatefulQoS, Connect, Subscribe, Publish and both
+    ProcessLoop sites) now print the symbolic name alongside the number, via
+    coreMQTT's own `MQTT_Status_strerror()` — `MQTT_Connect failed:
+    MQTTServerRefused (6)`. The number is kept so existing logs and tickets
+    still line up.
+  - `docs-site/docs/reference/iot-client.md` gains a `MQTTStatus_t` table (for
+    reading older logs, which carry only the number) and a CONNACK refusal-code
+    table, noting that codes 4/5 usually mean the device was unbound in the
+    cloud rather than a wrong password, and how to confirm that over ATOP. The
+    sample output is the verbatim four-line block the SDK emits, timestamps
+    included — a paraphrase there defeats the page's only purpose.
+
+### Fixed
+
+- iot-client — a peer that closed a non-TLS MQTT connection went unnoticed until
+  the 60 s keepalive expired. `pal.h` defines a 0 from `tcp_recv` as EOF, but
+  coreMQTT reads a 0 from the transport as "no data yet", so `transport_recv()`
+  had to translate it — which the TLS branch did, with a comment explaining
+  exactly this, while the TCP branch (`mqtt_disable_tls = true`) passed it
+  straight through. Pinned by `test_closed_peer_is_reported`.
+
+- iot-client — tearing down an already-dead link no longer pushes a DISCONNECT
+  packet into a socket that cannot carry it. `mqtt_client_process()` now records
+  that the link died and `mqtt_client_disconnect()` skips only the packet, still
+  releasing the socket and buffer (clearing `connected` instead would have made
+  the teardown return early and leak both). This became worth fixing once
+  coreMQTT's errors were audible: the failed send is logged at ERROR level, so a
+  device reconnecting on a flaky link would report two errors per cycle for an
+  ordinary teardown. Not covered by a test — a just-killed peer usually absorbs
+  one more send, so the failure does not reliably reproduce against a mock.
+
 - iot-client — generic ATOP call (`iot_atop_call`), for cloud interfaces the SDK
   does not wrap by name.
   - New public header `iot_atop.h`: pass an `api` name, its `version` and a JSON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,12 +99,29 @@ add_library(core_mqtt STATIC
     "${coremqtt_source_dir}/source/core_mqtt_serializer.c"
     "${coremqtt_source_dir}/source/core_mqtt_state.c"
 )
-target_compile_definitions(core_mqtt PUBLIC MQTT_DO_NOT_USE_CUSTOM_CONFIG)
-
-target_include_directories(core_mqtt PUBLIC
-    "${coremqtt_source_dir}/source/include"
-    "${coremqtt_source_dir}/source/interface"
+# No MQTT_DO_NOT_USE_CUSTOM_CONFIG: coreMQTT picks up common/core_mqtt_config.h,
+# which routes its Error/Warn logs into the SDK log facade. Without it a refused
+# CONNECT reaches the caller as a bare MQTTServerRefused, with the broker's
+# actual reason discarded inside coreMQTT.
+#
+# `common` is PRIVATE: only coreMQTT's own three .c files include
+# core_mqtt_config_defaults.h (and through it core_mqtt_config.h) -- core_mqtt.h
+# does not, so consumers need nothing. PUBLIC would put this repo's `common/` on
+# every consumer's include path, where generic names like log.h and tls.h can
+# shadow an integrator's own headers.
+target_include_directories(core_mqtt
+    PUBLIC
+        "${coremqtt_source_dir}/source/include"
+        "${coremqtt_source_dir}/source/interface"
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/common"
 )
+
+# coreMQTT's objects now reference log_emit(). Declare it: without this the link
+# only succeeds because some other archive happens to be scanned first and drags
+# log.o in -- a target that links core_mqtt alone would fail. agentic_kit_common
+# is defined further down; CMake resolves target names regardless of order.
+target_link_libraries(core_mqtt PRIVATE agentic_kit_common)
 
 # -----------------------------------------------------------------------------
 # Common library (process-wide log facade, shared TLS transport, etc.)

--- a/common/core_mqtt_config.h
+++ b/common/core_mqtt_config.h
@@ -1,0 +1,46 @@
+/**
+ * @file core_mqtt_config.h
+ * @brief Route coreMQTT's internal Error/Warn logging into the SDK log facade.
+ *
+ * coreMQTT was built with MQTT_DO_NOT_USE_CUSTOM_CONFIG, which leaves its
+ * `Log*` macros expanding to nothing (core_mqtt_config_defaults.h). That
+ * silence has a concrete cost: a broker that refuses a CONNECT surfaces at the
+ * call site only as `MQTTServerRefused` (6) — while coreMQTT knew, and threw
+ * away, which of the five MQTT 3.1.1 refusal reasons the broker actually sent.
+ * `logConnackResponse()` in core_mqtt_serializer.c holds the answer
+ * ("bad user name or password", "identifier rejected", "not authorized", …) and
+ * logs it through exactly these macros.
+ *
+ * Only Error and Warn are routed on purpose. LogInfo/LogDebug fire per packet;
+ * wiring them would cost flash on an embedded target and bury the useful lines
+ * in per-publish chatter. They stay compiled out, exactly as before this file
+ * existed, so the only behavioural change here is that coreMQTT's failures
+ * become visible.
+ */
+
+#ifndef CORE_MQTT_CONFIG_H
+#define CORE_MQTT_CONFIG_H
+
+#include "log.h"
+
+/* coreMQTT invokes these with a doubly-parenthesised argument --
+ * LogError( ( "fmt", args ) ) -- so `message` arrives complete with its own
+ * parentheses, which then serve as the call parentheses of the macro below.
+ * Same shape as the log_* wrappers in iot_config_defaults.h. */
+#define CORE_MQTT_LOG_ERROR( ... ) log_emit(LOG_ERROR, "[mqtt] " __VA_ARGS__)
+#define CORE_MQTT_LOG_WARN( ... )  log_emit(LOG_WARN,  "[mqtt] " __VA_ARGS__)
+
+/* #undef first: coreHTTP's core_http_config_defaults.h defines both as empty
+ * under its own #ifndef. A translation unit that reached that header first
+ * would otherwise take the empty definition and silently lose these logs (or
+ * warn about a redefinition). No SDK source includes both today; this keeps the
+ * header order-independent for integrators who do. */
+#undef LogError
+#undef LogWarn
+#define LogError( message ) CORE_MQTT_LOG_ERROR message
+#define LogWarn( message )  CORE_MQTT_LOG_WARN message
+
+/* LogInfo / LogDebug deliberately left undefined -- core_mqtt_config_defaults.h
+ * guards each with #ifndef and falls back to an empty definition. */
+
+#endif /* CORE_MQTT_CONFIG_H */

--- a/docs-site/docs/reference/iot-client.md
+++ b/docs-site/docs/reference/iot-client.md
@@ -42,6 +42,52 @@ IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.
 | -6 | `OPRT_MALLOC_FAILED` | 内存分配失败 |
 | -7 | `OPRT_TLS_HANDSHAKE_FAILED` | TLS 握手失败 |
 
+### MQTT 状态码（`MQTTStatus_t`）
+
+日志形如 `MQTT_Connect failed: MQTTServerRefused (6)` 中括号里的数字。**现在的日志会同时打出名字**，本表主要用于查阅早期日志和历史工单里只有裸数字的情况。
+
+| 值 | 名称 | 在本 SDK 场景下的含义 |
+|----|------|------|
+| 0 | `MQTTSuccess` | 成功 |
+| 1 | `MQTTBadParameter` | 参数非法（本地问题，不会到达网络）|
+| 2 | `MQTTNoMemory` | 缓冲区不足，收发包放不下 |
+| 3 | `MQTTSendFailed` | 底层发送失败——网络已断，或 TLS 会话失效 |
+| 4 | `MQTTRecvFailed` | 底层接收失败，同上 |
+| 5 | `MQTTBadResponse` | 收到了报文但格式非法（对端不是合法 MQTT broker，或链路串包）|
+| 6 | `MQTTServerRefused` | **broker 明确拒绝**了 CONNECT 或 SUBSCRIBE——网络完全正常，是业务层不允许。见下表 |
+| 7 | `MQTTNoDataAvailable` | 本次没有数据可读，正常轮询结果 |
+| 8 | `MQTTIllegalState` | 状态机非法状态 |
+| 9 | `MQTTStateCollision` | QoS 报文 ID 冲突 |
+| 10 | `MQTTKeepAliveTimeout` | 等待 PINGRESP 超时，链路已死但 socket 未报错 |
+| 11 | `MQTTNeedMoreBytes` | 报文不完整，需再次调用（非错误）|
+
+### CONNACK 拒绝原因
+
+`MQTTServerRefused (6)` 只说明「被拒了」，具体哪一种由 broker 在 CONNACK 里给出。一次被拒的连接实际会打出四行，**第一行**就是原因：
+
+```
+10:15:13 [E] [mqtt] Connection refused: bad user name or password.
+10:15:13 [E] [mqtt] CONNACK recv failed with status = MQTTServerRefused.
+10:15:13 [E] [mqtt] MQTT connection failed with status = MQTTServerRefused.
+10:15:13 [E] [iot] MQTT_Connect failed: MQTTServerRefused (6)
+```
+
+前三行来自 coreMQTT（`[mqtt]`），最后一行来自 SDK（`[iot]`）。时间戳前缀由默认日志处理器加上；若应用用 `log_set_handler()` 换了处理器，前缀形式取决于该实现。
+
+| CONNACK code | 文案 | 常见原因与处理 |
+|----|------|------|
+| 1 | unacceptable protocol version | broker 不支持 MQTT 3.1.1，基本不会出现 |
+| 2 | identifier rejected | clientId 不被接受——检查 devid 是否完整（正常为 20–22 字节）|
+| 3 | server unavailable | 云端临时不可用，退避重试即可，与凭据无关 |
+| 4 | bad user name or password | 凭据不被认可 |
+| 5 | not authorized | 未授权 |
+
+4 和 5 最常见，且**多数情况下不是密码算错**，而是**设备已在云端被解绑/删除**——凭据本身格式与算法都正确，只是服务端不再认这个 `devid`。快速确认方法：拿同一套凭据走 ATOP HTTP 打一个接口（如 `iot_atop_call` 调 `tuya.device.schema.newest.get`），ATOP 会原样带回云端的 `errorCode`，信息量远大于 CONNACK；若同样被拒，即可确认需要重新配网激活。
+
+:::note
+`[mqtt]` 前缀的行来自 coreMQTT 内部，由 `common/core_mqtt_config.h` 接入日志门面。若这些行没有出现，说明该构建仍带着 `MQTT_DO_NOT_USE_CUSTOM_CONFIG`，拒绝原因会被丢弃，只剩一个裸的 `6`。
+:::
+
 ## 枚举类型
 
 ### Region（`iot_region_t`）

--- a/examples/esp-idf/components/agentic_kit/CMakeLists.txt
+++ b/examples/esp-idf/components/agentic_kit/CMakeLists.txt
@@ -66,9 +66,12 @@ idf_component_register(
     REQUIRES mbedtls json freertos lwip esp_event esp_netif esp_timer esp_wifi
 )
 
+# No MQTT_DO_NOT_USE_CUSTOM_CONFIG: coreMQTT must pick up common/core_mqtt_config.h
+# here too, or a refused CONNECT logs only a bare MQTTServerRefused on exactly the
+# target this diagnostic exists for. ${AK_DIR}/common is already in INCLUDE_DIRS
+# above, so the header resolves with no further wiring.
 target_compile_definitions(${COMPONENT_LIB} PRIVATE
     HTTP_DO_NOT_USE_CUSTOM_CONFIG
-    MQTT_DO_NOT_USE_CUSTOM_CONFIG
     IOT_DO_NOT_USE_CUSTOM_CONFIG
 )
 

--- a/modules/iot-client/src/mqtt.c
+++ b/modules/iot-client/src/mqtt.c
@@ -63,6 +63,11 @@ struct mqtt_client {
     mqtt_message_callback_t message_callback;
     void *user_data;
     bool connected;
+    /* Set when the link is known dead (a failed process loop). Kept separate
+     * from `connected`, which still gates the teardown below: clearing that
+     * instead would make mqtt_client_disconnect() return early and leak the TLS
+     * context and the MQTT buffer. */
+    bool link_dead;
     bool use_tls;
     const char *cacert;
     tls_cert_bundle_attach_fn cert_bundle_attach;
@@ -149,6 +154,15 @@ static int32_t transport_recv(NetworkContext_t *pNetworkContext,
         }
         if (bytes_received < 0) {
             log_error("TCP recv failed: %d", bytes_received);
+            return OPRT_COMMUNICATION_ERROR;
+        }
+        if (bytes_received == 0) {
+            /* 0 is EOF per the PAL contract (pal.h) -- the peer closed. Same
+             * reasoning as the TLS branch above: handing coreMQTT a 0 reads as
+             * an idle poll, so a dropped link would go unnoticed until the
+             * 60 s keepalive expired. This branch used to be the asymmetric
+             * one; only mqtt_disable_tls=true builds ever reached it. */
+            log_error("TCP peer closed the connection");
             return OPRT_COMMUNICATION_ERROR;
         }
         return (int32_t)bytes_received;
@@ -417,7 +431,7 @@ int mqtt_client_connect(mqtt_client *client) {
     MQTTStatus_t status = MQTT_Init(&client->mqtt_context, &client->transport,
                                     mqtt_get_time_ms, mqtt_event_callback, &client->fixed_buffer);
     if (status != MQTTSuccess) {
-        log_error("MQTT_Init failed: %d", status);
+        log_error("MQTT_Init failed: %s (%d)", MQTT_Status_strerror(status), status);
         if (client->use_tls) {
             tls_cleanup(&client->network_context);
         } else {
@@ -435,7 +449,7 @@ int mqtt_client_connect(mqtt_client *client) {
                                    client->incoming_publish_records,
                                    MQTT_QOS_RECORD_COUNT);
     if (status != MQTTSuccess) {
-        log_error("MQTT_InitStatefulQoS failed: %d", status);
+        log_error("MQTT_InitStatefulQoS failed: %s (%d)", MQTT_Status_strerror(status), status);
         if (client->use_tls) {
             tls_cleanup(&client->network_context);
         } else {
@@ -469,7 +483,7 @@ int mqtt_client_connect(mqtt_client *client) {
                          MQTT_SEND_TIMEOUT_MS, &sessionPresent);
 
     if (status != MQTTSuccess) {
-        log_error("MQTT_Connect failed: %d", status);
+        log_error("MQTT_Connect failed: %s (%d)", MQTT_Status_strerror(status), status);
         if (client->use_tls) {
             tls_cleanup(&client->network_context);
         } else {
@@ -481,6 +495,7 @@ int mqtt_client_connect(mqtt_client *client) {
     }
 
     client->connected = true;
+    client->link_dead = false;
     log_info("Successfully connected to MQTT broker");
     return OPRT_OK;
 }
@@ -506,7 +521,7 @@ int mqtt_client_subscribe(mqtt_client *client) {
     MQTTStatus_t status = MQTT_Subscribe(&client->mqtt_context, &subscribe_info, 1, packet_id);
 
     if (status != MQTTSuccess) {
-        log_error("MQTT_Subscribe failed: %d", status);
+        log_error("MQTT_Subscribe failed: %s (%d)", MQTT_Status_strerror(status), status);
         return OPRT_COMMUNICATION_ERROR;
     }
 
@@ -525,7 +540,7 @@ int mqtt_client_subscribe(mqtt_client *client) {
                 return OPRT_COMMUNICATION_ERROR;
             }
         } else if (status != MQTTNeedMoreBytes) {
-            log_error("MQTT_ProcessLoop failed while waiting for SUBACK: %d", status);
+            log_error("MQTT_ProcessLoop failed while waiting for SUBACK: %s (%d)", MQTT_Status_strerror(status), status);
             return OPRT_COMMUNICATION_ERROR;
         }
         usleep(100000);
@@ -557,7 +572,7 @@ int mqtt_client_publish(mqtt_client *client, const char *topic,
                                       MQTT_GetPacketId(&client->mqtt_context));
 
     if (status != MQTTSuccess) {
-        log_error("MQTT_Publish failed: %d", status);
+        log_error("MQTT_Publish failed: %s (%d)", MQTT_Status_strerror(status), status);
         return OPRT_COMMUNICATION_ERROR;
     }
 
@@ -578,7 +593,8 @@ int mqtt_client_process(mqtt_client *client, uint32_t timeout_ms) {
     MQTTStatus_t status = MQTT_ProcessLoop(&client->mqtt_context);
 
     if (status != MQTTSuccess && status != MQTTNeedMoreBytes) {
-        log_error("MQTT_ProcessLoop failed: %d", status);
+        log_error("MQTT_ProcessLoop failed: %s (%d)", MQTT_Status_strerror(status), status);
+        client->link_dead = true;
         return OPRT_COMMUNICATION_ERROR;
     }
 
@@ -591,7 +607,14 @@ void mqtt_client_disconnect(mqtt_client *client) {
         return;
     }
 
-    MQTT_Disconnect(&client->mqtt_context);
+    /* A DISCONNECT on a link the process loop already found dead cannot arrive.
+     * It is not merely useless: coreMQTT reports the failed send at ERROR level,
+     * so an app reconnecting on a flaky network would log two errors per cycle
+     * for an ordinary teardown. Everything below still runs -- the socket and
+     * buffer must be released either way. */
+    if (!client->link_dead) {
+        MQTT_Disconnect(&client->mqtt_context);
+    }
 
     if (client->use_tls) {
         tls_cleanup(&client->network_context);

--- a/modules/iot-client/test/mqtt_test.c
+++ b/modules/iot-client/test/mqtt_test.c
@@ -5,10 +5,12 @@
 #include <unistd.h>
 #include <sys/wait.h>
 #include <stdbool.h>
+#include <stdarg.h>   /* capture_log_handler takes a va_list */
 
 #include "mqtt.h"
 #include "iot_client.h"
 #include "iot_config_defaults.h"
+#include "log.h"
 
 #define TEST_CLIENT_ID   "mqtt_test_client"
 #define TEST_USERNAME    "test_user"
@@ -376,6 +378,160 @@ static int test_connect_auth_fail(void)
     return OPRT_OK;
 }
 
+/* ---------- Test: the broker's refusal reason reaches the log ---------- */
+
+/* coreMQTT knows which of the five MQTT 3.1.1 refusal reasons the broker sent,
+ * but only says so through its Log* macros. Those expand to nothing unless the
+ * build picks up common/core_mqtt_config.h, and nothing else in this suite
+ * notices if it stops doing so: test_connect_auth_fail passes either way, since
+ * it only asserts that connect failed.
+ *
+ * So assert the routing itself. Without it the caller is left with a bare
+ * MQTTServerRefused and no way to tell "wrong password" from "device unbound in
+ * the cloud" -- which is the whole reason the wiring exists. */
+
+static char log_capture[4096];
+static size_t log_capture_len;
+static log_fn_t saved_log_fn;
+
+static void capture_log_handler(log_level_t level, const char *fmt, va_list args)
+{
+    char line[512];
+    int n = vsnprintf(line, sizeof(line), fmt, args);
+    if (n > 0 && log_capture_len + (size_t)n + 1 < sizeof(log_capture)) {
+        memcpy(log_capture + log_capture_len, line, (size_t)n);
+        log_capture_len += (size_t)n;
+        log_capture[log_capture_len++] = '\n';
+        log_capture[log_capture_len] = '\0';
+    }
+    /* Keep the default output too, so a failing run is still readable. */
+    log_default_handler(level, fmt, args);
+}
+
+static void capture_start(void)
+{
+    log_capture[0] = '\0';
+    log_capture_len = 0;
+    saved_log_fn = capture_log_handler;
+    log_set_handler(capture_log_handler);
+}
+
+static void capture_stop(void)
+{
+    log_set_handler(NULL);
+    (void)saved_log_fn;
+}
+
+static int test_connack_reason_is_logged(void)
+{
+    const pal_t *pal = get_default_pal();
+    mqtt_client_config_t config = {
+        .broker_url      = MOCK_BROKER_URL,
+        .client_id       = TEST_CLIENT_ID,
+        .password        = "wrong_password",   /* mock answers CONNACK code 4 */
+        .subscribe_topic = TEST_TOPIC_SUB,
+        .callback        = test_message_callback,
+        .pal             = pal,
+    };
+    mqtt_client *c = mqtt_client_create_with_config(&config);
+    if (!c) {
+        printf("  create failed\n");
+        return -1;
+    }
+
+    capture_start();
+    int ret = mqtt_client_connect(c);
+    capture_stop();
+
+    int result = 0;
+    if (ret == 0) {
+        printf("  expected connect to fail with bad password\n");
+        result = -1;
+    }
+
+    /* coreMQTT's own words, routed through common/core_mqtt_config.h. */
+    if (strstr(log_capture, "bad user name or password") == NULL) {
+        printf("  the broker's refusal reason never reached the log --\n");
+        printf("  is MQTT_DO_NOT_USE_CUSTOM_CONFIG back, or common/ off coreMQTT's include path?\n");
+        result = -1;
+    }
+    /* And our own line still names the status symbolically. */
+    if (strstr(log_capture, "MQTTServerRefused") == NULL) {
+        printf("  expected the symbolic status name in the SDK log line\n");
+        result = -1;
+    }
+
+    mqtt_client_destroy(c);
+    return result;
+}
+
+/* ---------- Test: a closed peer is reported, not polled forever ---------- */
+
+/* transport_recv() must translate EOF into an error. The PAL contract (pal.h)
+ * defines a 0 from tcp_recv as EOF, but coreMQTT reads a 0 from the transport as
+ * "nothing to read right now" -- so handing it straight through means a dropped
+ * link goes unnoticed until the 60 s keepalive expires. The TLS branch always
+ * got this right and says so in a comment; the TCP branch (mqtt_disable_tls=true)
+ * did not, until this test was written.
+ *
+ * Killing the broker mid-session is what a dropped link looks like from here.
+ * The teardown that follows also walks mqtt_client_disconnect()'s dead-link
+ * path, which is worth exercising even though its DISCONNECT suppression cannot
+ * be asserted here: a just-killed peer usually still absorbs one send, so the
+ * failure coreMQTT would log does not reliably occur against a mock. */
+static int test_closed_peer_is_reported(void)
+{
+    const pal_t *pal = get_default_pal();
+    mqtt_client_config_t config = {
+        .broker_url      = MOCK_BROKER_URL,
+        .client_id       = TEST_CLIENT_ID,
+        .password        = TEST_PASSWORD,
+        .subscribe_topic = TEST_TOPIC_SUB,
+        .callback        = test_message_callback,
+        .pal             = pal,
+    };
+    mqtt_client *c = mqtt_client_create_with_config(&config);
+    if (!c) {
+        printf("  create failed\n");
+        return -1;
+    }
+    if (mqtt_client_connect(c) != 0) {
+        printf("  connect failed\n");
+        mqtt_client_destroy(c);
+        return -1;
+    }
+
+    stop_mock_server();          /* the link dies under us */
+
+    int result = 0;
+    /* Drive the loop until it notices. One call is usually enough; a few gives
+     * the socket time to report the peer going away. */
+    int rc = OPRT_OK;
+    for (int i = 0; i < 20 && rc == OPRT_OK; i++) {
+        rc = mqtt_client_process(c, 100);
+    }
+    if (rc == OPRT_OK) {
+        printf("  the process loop never noticed the peer had closed --\n");
+        printf("  does transport_recv() still hand coreMQTT a bare 0 on EOF?\n");
+        mqtt_client_destroy(c);
+        start_mock_server();
+        return -1;
+    }
+
+    /* The teardown an app's reconnect loop performs. Asserted only to not crash
+     * or hang; see the note above on why the DISCONNECT suppression itself is
+     * not observable against a mock. */
+    mqtt_client_disconnect(c);
+    if (mqtt_client_is_connected(c)) {
+        printf("  still reports connected after disconnect\n");
+        result = -1;
+    }
+
+    mqtt_client_destroy(c);
+    start_mock_server();         /* restore for the tests that follow */
+    return result;
+}
+
 /* ---------- Test: subscribe failure ---------- */
 
 static int test_subscribe_fail(void)
@@ -682,6 +838,8 @@ int main(void)
     RUN_TEST(test_subscribe);
     RUN_TEST(test_publish_receive);
     RUN_TEST(test_connect_auth_fail);
+    RUN_TEST(test_connack_reason_is_logged);
+    RUN_TEST(test_closed_peer_is_reported);
     RUN_TEST(test_subscribe_fail);
     RUN_TEST(test_connect_tls_cert_fail);
     RUN_TEST(test_connect_tls_auth_fail);


### PR DESCRIPTION
… status number

Diagnosing a refused MQTT connect from a device log was guesswork. All the log carried was:

    [E] [iot] MQTT_Connect failed: 6

Two separate things were hiding the answer.

First, coreMQTT was built with MQTT_DO_NOT_USE_CUSTOM_CONFIG, so its Log* macros expanded to nothing (core_mqtt_config_defaults.h). coreMQTT knew exactly which of the five MQTT 3.1.1 refusal reasons the broker had sent -- logConnackResponse() formats it in plain words -- and logged it into a void. common/core_mqtt_config.h routes its Error/Warn into the SDK log facade. LogInfo/LogDebug stay compiled out: they fire per packet, would cost flash on an embedded target, and would bury the useful lines. Nothing is added to the hot path.

Second, the SDK's own log lines printed a raw MQTTStatus_t, so reading one meant looking the number up in a header. All seven sites (Init, InitStatefulQoS, Connect, Subscribe, Publish, and both ProcessLoop sites) now print the symbolic name via coreMQTT's own MQTT_Status_strerror(). The number is kept alongside, since existing logs and tickets quote it.

The same failure now reads:

    [E] [mqtt] Connection refused: bad user name or password.
    [E] [mqtt] CONNACK recv failed with status = MQTTServerRefused.
    [E] [iot] MQTT_Connect failed: MQTTServerRefused (6)

SUBSCRIBE refusals, previously just as silent, are visible too.

Both build paths are wired. examples/esp-idf/components/agentic_kit carries its own target_compile_definitions, so wiring only the root CMakeLists.txt would have left the feature absent on exactly the embedded target it exists for -- and AGENTS.md notes that no CI job runs idf.py, so the omission would not surface until someone flashed a board.

`common` is PRIVATE on core_mqtt: only coreMQTT's own three .c files include core_mqtt_config_defaults.h, and through it core_mqtt_config.h; core_mqtt.h does not, so consumers need nothing. PUBLIC would put this repo's common/ on every consumer's include path, where generic names like log.h and tls.h can shadow an integrator's own headers. core_mqtt also declares its dependency on agentic_kit_common, since its objects now reference log_emit() -- otherwise the link resolves only when another archive happens to be scanned first.

Making coreMQTT audible surfaced two transport defects, fixed here:

- A closed peer went unnoticed for up to 60 s on non-TLS links. pal.h defines a 0 from tcp_recv as EOF, but coreMQTT reads a 0 from the transport as "nothing to read right now", so transport_recv() has to translate it. Only the TLS branch did, with a comment spelling out that otherwise "the dead link would only be noticed at the keepalive timeout" -- while the TCP branch immediately below passed the 0 straight through. Found when a test that kills the broker could not get the process loop to notice, twenty iterations in.

- Tearing down an already-dead link pushed a DISCONNECT packet into a socket that cannot carry it. That send cannot succeed, and is no longer silent either: two ERROR lines per reconnect cycle, on exactly the flaky links where reconnects are frequent. Recorded with a separate link_dead flag rather than by clearing `connected`, which would trip mqtt_client_disconnect()'s own guard and leak the TLS context and MQTT buffer -- the teardown still has to run, only the packet must not be sent.

test_connack_reason_is_logged captures the log facade and asserts the broker's words arrive; the pre-existing test_connect_auth_fail drives the same refusal but asserts only the return code, so it passes with the routing disabled and cannot protect it. test_closed_peer_is_reported pins the EOF fix -- reverting that hunk drops iot_mqtt_test to 15/16. The DISCONNECT suppression is deliberately left untested and its comment says so: a just-killed peer usually absorbs one more send, so the failure does not reproduce reliably against a mock.

The reference doc gains an MQTTStatus_t table (for older logs, which carry only the number) and a CONNACK refusal-code table, written as "what this means here": most usefully, that codes 4 and 5 usually mean the device was unbound in the cloud rather than a mistyped password, and how to confirm that over ATOP. The sample output is the verbatim four-line block, timestamps included.

Verified: full build clean; ctest 13/13; iot_mqtt_test 16/16 (2 new).