### PR TITLE
feat(iot-client): route coreHTTP's errors into the log facade, and fo…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,13 +55,17 @@ ctest --test-dir build --output-on-failure --no-tests=error --timeout 180   # ne
   to it is verifiable offline. The root CMakeLists declares `tuya_steam_client` only when the
   current platform's `libstm.a` exists (its if/elseif chain covers three of the five
   architectures on disk).
-- **coreHTTP is built with its custom-config hook disabled** (`HTTP_DO_NOT_USE_CUSTOM_CONFIG`),
-  so its own error logging expands to nothing — expect no diagnostics from it. coreMQTT is the
-  exception and must stay that way: it picks up `common/core_mqtt_config.h`, which routes its
-  Error/Warn into the log facade so a broker's refusal reason survives (`Connection refused: bad
-  user name or password.`); without it a rejected CONNECT is a bare `MQTTServerRefused`. Both
-  build paths matter — the root `CMakeLists.txt` **and** `examples/esp-idf/components/agentic_kit`,
-  which had to be fixed separately. coreMQTT's thread-safety hooks are still unset.
+- **coreMQTT and coreHTTP route their Error/Warn logs into the log facade** via
+  `common/core_mqtt_config.h` and `common/core_http_config.h`, and must keep doing so. Setting
+  `MQTT_DO_NOT_USE_CUSTOM_CONFIG` / `HTTP_DO_NOT_USE_CUSTOM_CONFIG` again silently discards each
+  library's own account of a failure: a rejected CONNECT decays to a bare `MQTTServerRefused` with
+  no `Connection refused: bad user name or password.`, and an oversized response to a generic
+  communication error with no `insufficient space`. Both build paths must be kept in step — the
+  root `CMakeLists.txt` **and** `examples/esp-idf/components/agentic_kit`, which carries its own
+  `target_compile_definitions` and was for a while the path where none of this reached a device.
+  Pinned by `test_connack_reason_is_logged` and `test_oversized_response_is_explained`.
+  `LogInfo`/`LogDebug` stay compiled out on purpose (per-packet, costly on flash), and coreMQTT's
+  thread-safety hooks are still unset.
 
 ## Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     sample output is the verbatim four-line block the SDK emits, timestamps
     included — a paraphrase there defeats the page's only purpose.
 
+- common — coreHTTP's Error/Warn logs are routed into the log facade too
+  (`common/core_http_config.h`), completing the pair. This is the half that
+  matters when MQTT is already refusing: the docs send the reader to ATOP over
+  HTTP to ask whether the credentials are still valid, and that path had no
+  diagnostics of its own. An oversized response — the failure recorded below at
+  contentLength 6558 — now says `insufficient space: responseBufferLen=...`
+  instead of surfacing as a generic communication error.
+  - The include directory is PUBLIC here where coreMQTT's is PRIVATE, and the
+    asymmetry is real rather than an oversight: `core_http_client.h` includes
+    `core_http_config_defaults.h` itself, so every consumer of the header needs
+    the path, whereas only coreMQTT's own `.c` files do.
+  - Pinned by `test_oversized_response_is_explained`, with a mock API that
+    returns a deliberately over-sized envelope. Verified to bite: restoring
+    `HTTP_DO_NOT_USE_CUSTOM_CONFIG` drops `iot_atop_call_test` to 13/14.
+
+- iot-client — the three byte-identical cleanup blocks in `mqtt_client_connect()`
+  (after `MQTT_Init`, `MQTT_InitStatefulQoS` and `MQTT_Connect`) are now one
+  `mqtt_abort_connect()`. They were a standing hazard rather than just noise: a
+  fix to the teardown sequence applied to one copy could silently miss the other
+  two, and a nearby teardown fix had just landed on this branch.
+
 ### Fixed
 
 - iot-client — a peer that closed a non-TLS MQTT connection went unnoticed until

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,13 +86,23 @@ add_library(core_http STATIC
     "${corehttp_source_dir}/source/dependency/3rdparty/llhttp/src/http.c"
     "${corehttp_source_dir}/source/dependency/3rdparty/llhttp/src/llhttp.c"
 )
-target_compile_definitions(core_http PUBLIC HTTP_DO_NOT_USE_CUSTOM_CONFIG)
-
+# No HTTP_DO_NOT_USE_CUSTOM_CONFIG: coreHTTP picks up common/core_http_config.h,
+# routing its Error/Warn into the log facade — the counterpart to coreMQTT above,
+# and the half that matters on the ATOP path the MQTT refusal docs send people to.
+#
+# `common` is PUBLIC here, unlike coreMQTT's PRIVATE: core_http_client.h itself
+# includes core_http_config_defaults.h (and through it core_http_config.h), so
+# every consumer of the header — http_client_interface.c — needs the path too.
 target_include_directories(core_http PUBLIC
     "${corehttp_source_dir}/source/include"
     "${corehttp_source_dir}/source/interface"
     "${corehttp_source_dir}/source/dependency/3rdparty/llhttp/include"
+    "${CMAKE_CURRENT_SOURCE_DIR}/common"
 )
+
+# coreHTTP's objects now reference log_emit(); declare it rather than relying on
+# archive scan order. Same reasoning as core_mqtt.
+target_link_libraries(core_http PRIVATE agentic_kit_common)
 
 add_library(core_mqtt STATIC
     "${coremqtt_source_dir}/source/core_mqtt.c"

--- a/common/core_http_config.h
+++ b/common/core_http_config.h
@@ -1,0 +1,41 @@
+/**
+ * @file core_http_config.h
+ * @brief Route coreHTTP's internal Error/Warn logging into the SDK log facade.
+ *
+ * The counterpart to core_mqtt_config.h, for the same reason: without it
+ * coreHTTP's `Log*` macros expand to nothing (core_http_config_defaults.h) and
+ * its own account of a failure never reaches anyone. That matters most on the
+ * ATOP path, which is the fallback diagnosis the MQTT refusal docs point at —
+ * when a device cannot connect, ATOP over HTTP is how you ask the cloud whether
+ * the credentials are still valid, and it was the half with no diagnostics.
+ *
+ * Only Error and Warn are routed, as with coreMQTT: LogDebug fires per response
+ * chunk, so wiring it would cost flash on an embedded target and bury the
+ * useful lines. LogInfo/LogDebug stay compiled out, leaving this a
+ * diagnostics-only change with nothing added to the hot path.
+ */
+
+#ifndef CORE_HTTP_CONFIG_H
+#define CORE_HTTP_CONFIG_H
+
+#include "log.h"
+
+/* coreHTTP invokes these with a doubly-parenthesised argument --
+ * LogError( ( "fmt", args ) ) -- so `message` arrives complete with its own
+ * parentheses, which then serve as the call parentheses of the macro below. */
+#define CORE_HTTP_LOG_ERROR( ... ) log_emit(LOG_ERROR, "[http] " __VA_ARGS__)
+#define CORE_HTTP_LOG_WARN( ... )  log_emit(LOG_WARN,  "[http] " __VA_ARGS__)
+
+/* #undef first, mirroring core_mqtt_config.h: whichever of the two vendored
+ * config headers a translation unit reaches second must win rather than warn.
+ * The two libraries compile separately, so in practice each sees only its own
+ * prefix; this only keeps a TU that includes both headers well-defined. */
+#undef LogError
+#undef LogWarn
+#define LogError( message ) CORE_HTTP_LOG_ERROR message
+#define LogWarn( message )  CORE_HTTP_LOG_WARN message
+
+/* LogInfo / LogDebug deliberately left undefined -- core_http_config_defaults.h
+ * guards each with #ifndef and falls back to an empty definition. */
+
+#endif /* CORE_HTTP_CONFIG_H */

--- a/examples/esp-idf/components/agentic_kit/CMakeLists.txt
+++ b/examples/esp-idf/components/agentic_kit/CMakeLists.txt
@@ -71,7 +71,6 @@ idf_component_register(
 # target this diagnostic exists for. ${AK_DIR}/common is already in INCLUDE_DIRS
 # above, so the header resolves with no further wiring.
 target_compile_definitions(${COMPONENT_LIB} PRIVATE
-    HTTP_DO_NOT_USE_CUSTOM_CONFIG
     IOT_DO_NOT_USE_CUSTOM_CONFIG
 )
 

--- a/modules/iot-client/src/mqtt.c
+++ b/modules/iot-client/src/mqtt.c
@@ -387,6 +387,23 @@ static void release_mqtt_buffer(mqtt_client *client) {
     client->fixed_buffer.size = 0;
 }
 
+/* Unwind a half-built connection: drop the transport, hand back the MQTT buffer.
+ * Shared by the three failure points that sit between a live socket and a usable
+ * MQTT session (Init, InitStatefulQoS, Connect), which were three byte-identical
+ * copies -- a fix applied to one of them could silently miss the other two.
+ * Returns the error so each site stays a single `return`. */
+static int mqtt_abort_connect(mqtt_client *client)
+{
+    if (client->use_tls) {
+        tls_cleanup(&client->network_context);
+    } else {
+        client->pal->tcp_close(client->network_context.tcp_handle);
+        client->network_context.tcp_handle = NULL;
+    }
+    release_mqtt_buffer(client);
+    return OPRT_COMMUNICATION_ERROR;
+}
+
 // Connect to MQTT broker
 int mqtt_client_connect(mqtt_client *client) {
     if (!client) {
@@ -432,14 +449,7 @@ int mqtt_client_connect(mqtt_client *client) {
                                     mqtt_get_time_ms, mqtt_event_callback, &client->fixed_buffer);
     if (status != MQTTSuccess) {
         log_error("MQTT_Init failed: %s (%d)", MQTT_Status_strerror(status), status);
-        if (client->use_tls) {
-            tls_cleanup(&client->network_context);
-        } else {
-            client->pal->tcp_close(client->network_context.tcp_handle);
-            client->network_context.tcp_handle = NULL;
-        }
-        release_mqtt_buffer(client);
-        return OPRT_COMMUNICATION_ERROR;
+        return mqtt_abort_connect(client);
     }
 
     // Initialize QoS1 and QoS2 support
@@ -450,14 +460,7 @@ int mqtt_client_connect(mqtt_client *client) {
                                    MQTT_QOS_RECORD_COUNT);
     if (status != MQTTSuccess) {
         log_error("MQTT_InitStatefulQoS failed: %s (%d)", MQTT_Status_strerror(status), status);
-        if (client->use_tls) {
-            tls_cleanup(&client->network_context);
-        } else {
-            client->pal->tcp_close(client->network_context.tcp_handle);
-            client->network_context.tcp_handle = NULL;
-        }
-        release_mqtt_buffer(client);
-        return OPRT_COMMUNICATION_ERROR;
+        return mqtt_abort_connect(client);
     }
     log_info("QoS1 and QoS2 support initialized");
 
@@ -484,14 +487,7 @@ int mqtt_client_connect(mqtt_client *client) {
 
     if (status != MQTTSuccess) {
         log_error("MQTT_Connect failed: %s (%d)", MQTT_Status_strerror(status), status);
-        if (client->use_tls) {
-            tls_cleanup(&client->network_context);
-        } else {
-            client->pal->tcp_close(client->network_context.tcp_handle);
-            client->network_context.tcp_handle = NULL;
-        }
-        release_mqtt_buffer(client);
-        return OPRT_COMMUNICATION_ERROR;
+        return mqtt_abort_connect(client);
     }
 
     client->connected = true;

--- a/modules/iot-client/test/iot_atop_call_test.c
+++ b/modules/iot-client/test/iot_atop_call_test.c
@@ -28,6 +28,9 @@
 #include "iot_atop.h"
 #include "iot_client.h"
 #include "iot_config_defaults.h"
+#include "log.h"
+
+#include <stdarg.h>
 
 #define MOCK_HOST "127.0.0.1"
 #define MOCK_PORT 8443
@@ -459,6 +462,80 @@ static int test_unknown_api_reaches_the_cloud(void)
     return 0;
 }
 
+/* A response larger than RESPONSE_BUFFER_SIZE must fail loudly.
+ *
+ * This is the failure from CHANGELOG: a product whose schema came back at
+ * contentLength 6558 against a 4096 buffer, where coreHTTP returned
+ * HTTPInsufficientMemory and the caller reported a generic "communication
+ * error" — sending people to hunt the network for a buffer problem, after the
+ * server had already answered 200.
+ *
+ * Two things must hold now. The call still fails (the buffer really is too
+ * small), and coreHTTP says why, in its own words, through the log facade —
+ * which only happens while common/core_http_config.h is on its include path and
+ * HTTP_DO_NOT_USE_CUSTOM_CONFIG is not set. Nothing else in this suite notices
+ * if that wiring goes away, because every other case fits the buffer. */
+
+static char http_log_capture[8192];
+static size_t http_log_capture_len;
+
+static void http_capture_handler(log_level_t level, const char *fmt, va_list args)
+{
+    /* va_copy is mandatory, not tidiness: vsnprintf() below consumes `args`, and
+     * handing a consumed va_list to log_default_handler() -- which vfprintf()s
+     * it again -- is undefined behaviour (C11 7.16.1). It happened to work on
+     * macOS/arm64 and produced parameter-shifted garbage on Linux/x86-64, where
+     * a bogus "host:port" sent a test off connecting to nowhere until the CI
+     * timeout killed it. */
+    va_list copy;
+    va_copy(copy, args);
+    char line[1024];
+    int n = vsnprintf(line, sizeof(line), fmt, copy);
+    va_end(copy);
+    if (n > 0 && http_log_capture_len + (size_t)n + 1 < sizeof(http_log_capture)) {
+        memcpy(http_log_capture + http_log_capture_len, line, (size_t)n);
+        http_log_capture_len += (size_t)n;
+        http_log_capture[http_log_capture_len++] = '\n';
+        http_log_capture[http_log_capture_len] = '\0';
+    }
+    log_default_handler(level, fmt, args);
+}
+
+static int test_oversized_response_is_explained(void)
+{
+    char body[64];
+    snprintf(body, sizeof(body), "{\"t\":%u}", (unsigned)time(NULL));
+
+    iot_atop_request_t req = { .api = "tuya.test.huge.result",
+                               .version = "1.0",
+                               .data = body };
+    iot_atop_response_t resp = {0};
+
+    http_log_capture[0] = '\0';
+    http_log_capture_len = 0;
+    log_set_handler(http_capture_handler);
+    int rt = iot_atop_call(&g_client, &req, &resp);
+    log_set_handler(NULL);
+
+    int result = 0;
+    if (rt == OPRT_OK) {
+        printf("  expected the oversized response to fail, got OPRT_OK\n");
+        result = -1;
+    }
+    /* coreHTTP's own account, routed via common/core_http_config.h. */
+    if (strstr(http_log_capture, "insufficient space") == NULL) {
+        printf("  coreHTTP never explained the failure --\n");
+        printf("  is HTTP_DO_NOT_USE_CUSTOM_CONFIG back, or common/ off its include path?\n");
+        result = -1;
+    }
+    if (result == 0) {
+        printf("  oversized response rejected, and coreHTTP said why\n");
+    }
+
+    iot_atop_response_free(&g_client, &resp);
+    return result;
+}
+
 static int test_response_free_is_repeatable(void)
 {
     iot_atop_response_t resp = {0};
@@ -530,6 +607,7 @@ int main(void)
     RUN_TEST(test_null_result_stays_null);
     RUN_TEST(test_gateway_not_exists_is_business_error);
     RUN_TEST(test_response_zeroed_on_bad_request);
+    RUN_TEST(test_oversized_response_is_explained);
     RUN_TEST(test_response_free_is_repeatable);
 
     stop_mock_server();

--- a/modules/iot-client/test/mock/atop_mock.py
+++ b/modules/iot-client/test/mock/atop_mock.py
@@ -607,6 +607,17 @@ class ATOPMockHandler(BaseHTTPRequestHandler):
                 response_json = handle_version_update(decrypted_data, self.config)
             elif api == 'tuya.device.upgrade.status.update':
                 response_json = handle_upgrade_status_update(decrypted_data, self.config)
+            elif api == 'tuya.test.huge.result':
+                # Test-only: a response deliberately larger than the default
+                # 4096-byte RESPONSE_BUFFER_SIZE, reproducing the real failure
+                # recorded in CHANGELOG (a product whose schema came back at
+                # contentLength 6558). coreHTTP answers HTTPInsufficientMemory;
+                # the point of the test is that it now SAYS so.
+                response_json = json.dumps({
+                    "success": True,
+                    "t": int(time.time()),
+                    "result": {"blob": "x" * 6000}
+                }, separators=(',', ':'))
             elif api == 'tuya.test.result.null':
                 # Test-only: a success envelope whose result is JSON null --
                 # the generic entry must hand this back as NULL, not "null".

--- a/modules/iot-client/test/mqtt_test.c
+++ b/modules/iot-client/test/mqtt_test.c
@@ -396,8 +396,17 @@ static log_fn_t saved_log_fn;
 
 static void capture_log_handler(log_level_t level, const char *fmt, va_list args)
 {
+    /* va_copy is mandatory, not tidiness: vsnprintf() below consumes `args`, and
+     * handing a consumed va_list to log_default_handler() -- which vfprintf()s
+     * it again -- is undefined behaviour (C11 7.16.1). It happened to work on
+     * macOS/arm64 and produced parameter-shifted garbage on Linux/x86-64, where
+     * a bogus "host:port" sent a test off connecting to nowhere until the CI
+     * timeout killed it. */
+    va_list copy;
+    va_copy(copy, args);
     char line[512];
-    int n = vsnprintf(line, sizeof(line), fmt, args);
+    int n = vsnprintf(line, sizeof(line), fmt, copy);
+    va_end(copy);
     if (n > 0 && log_capture_len + (size_t)n + 1 < sizeof(log_capture)) {
         memcpy(log_capture + log_capture_len, line, (size_t)n);
         log_capture_len += (size_t)n;


### PR DESCRIPTION
…ld the duplicated abort path

coreMQTT was wired up in the previous commit, but coreHTTP had the identical hook still voided by HTTP_DO_NOT_USE_CUSTOM_CONFIG, so only half the problem was fixed.

That half matters. When MQTT is already refusing a device, the documented next step is to ask the cloud over ATOP whether the credentials are still valid -- and that path had no diagnostics of its own. An oversized response now reports `insufficient space: responseBufferLen=...` rather than decaying into a generic communication error: the same failure c65aa22 set out to name, now also in coreHTTP's own words.

The include directory is PUBLIC here where coreMQTT's is PRIVATE. The asymmetry was verified rather than copied: core_http_client.h includes core_http_config_defaults.h itself, so every consumer of that header needs the path, whereas for coreMQTT only its own .c files do.

Both build paths are wired -- the root CMakeLists.txt and the ESP-IDF component, which carries its own target_compile_definitions and was the path where none of this reached a device.

test_oversized_response_is_explained pins it, driving a new mock API that returns a deliberately over-sized envelope, reproducing the report from CHANGELOG: a product whose schema came back at contentLength 6558 against a 4096 buffer. Checked to actually bite -- restoring HTTP_DO_NOT_USE_CUSTOM_CONFIG drops iot_atop_call_test to 13/14.

AGENTS.md now records both libraries as one invariant, naming both build paths and both tests, replacing the entry that described the pre-change state.

Also folds the three byte-identical cleanup blocks in mqtt_client_connect() (after MQTT_Init, MQTT_InitStatefulQoS and MQTT_Connect) into one mqtt_abort_connect(). They were a hazard rather than just noise: a fix to the teardown sequence applied to one copy can silently miss the other two, and this line of work had just added one such fix a few lines away. The fourth, earlier cleanup site is left alone -- it runs before the transport is up, so it has nothing to close. No behaviour change from that part.

Verified: full build clean; ctest 13/13; iot_mqtt_test 16/16; iot_atop_call_test 14/14 (1 new); run_leaks_check.sh reports 0 leaks for both.