### PR TITLE
Mqtt auto connect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,8 +288,10 @@ ordinary changes.
 - **`iot_client_process(client, timeout_ms)` ignores `timeout_ms`.** The real blocking budget is
   the compile-time `MQTT_RECV_TIMEOUT_MS` (1000 ms), and the CONNECT sets a 60 s keepalive. Do
   not use the argument to pace the app loop.
-- **The "refreshes the CA and retries once" promise in `iot_client_message.h` and
-  `iot_client.h` is fiction** — no such code exists. The app owns cert recovery: call
-  `iot_get_ca_certificate()` and reassign `client->cacert` yourself (see
-  `examples/posix/dp-management/`). After a cloud cert rotation, a reconnect loop written
-  against that doc retries the same doomed handshake forever.
+- **`iot_client_connect()` never refreshes the CA and never retries.** The app owns cert
+  recovery: on `OPRT_TLS_HANDSHAKE_FAILED`, call `iot_get_ca_certificate()` and reassign
+  `client->cacert` yourself before reconnecting (see `examples/posix/dp-management/`).
+  A reconnect loop that skips this retries the same doomed handshake forever after a cloud
+  cert rotation. Both headers claimed the opposite until the API was made public; if that
+  "refreshes the CA and retries once" wording ever reappears, it is fiction — no such code
+  has ever existed in `iot_client_message_try_connect()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** iot-client — MQTT auto-connect is on by default. The
+  `mqtt_auto_connect` field is replaced by `mqtt_disable_auto_connect` on both
+  `iot_client_config_t` and `iot_on_boarding_config_t`.
+  - The rename is what makes the new default expressible: a zero-initialized
+    struct gives a `bool` `false`, so a field named `mqtt_auto_connect` can only
+    ever default to off. Reversing it follows `mqtt_disable_tls`, which already
+    reads "false (default) = TLS on" in the same structs.
+  - Existing code breaks at compile time rather than silently changing
+    behaviour, which is the point of the rename: `.mqtt_auto_connect = false`
+    becomes `.mqtt_disable_auto_connect = true`, and `.mqtt_auto_connect = true`
+    can simply be deleted.
+  - The failure path is deliberately unchanged: a failed auto-connect still
+    releases the client and returns `NULL` from `iot_client_init()`. That now
+    applies by default, so a device whose network may not be up at boot — or one
+    that only uses ATOP over HTTP with no broker, like `examples/posix/ota-demo`
+    — must set `mqtt_disable_auto_connect` and drive the link itself, or it will
+    fail to initialize instead of coming up and retrying.
+  - NOT covered by a test. Both existing auto-connect tests use an empty devid,
+    so `mqtt_url` stays empty and the branch short-circuits before the flag is
+    read — inverting the predicate leaves `iot_message_test` at 18/18. Proving
+    the default needs a DNS mock and a broker mock in the same suite, which none
+    of them currently has.
+
 ### Added
+
+- iot-client — MQTT connect/disconnect are now public API.
+  - New `iot_client_connect()` / `iot_client_disconnect()` in `iot_client.h`,
+    thin wrappers over the message layer in the same shape as the existing
+    `iot_client_process()` / `iot_client_publish()` pair.
+  - Publishing connect also exposed a latent leak, fixed here: connecting an
+    already-connected client built a second link and orphaned the first.
+    `iot_client_message_try_connect()` assigns `client->mqtt` unconditionally, so
+    the previous mqtt client, its packet buffer and its open socket were left
+    with nothing pointing at them. Reachable precisely because this API is now
+    public and documented as *the* way to bring the link up: an app that also
+    left `mqtt_auto_connect` true calls it on a live client. A second call is now
+    success without rebuilding — disconnect first to force a fresh link — and the
+    guard sits in the private entry point so every path is covered, including
+    init's auto-connect. Pinned by `test_connect_twice_keeps_one_link`.
+  - They close a real gap rather than adding a capability: `mqtt_auto_connect`
+    defaults to `false`, and the only way to bring the link up was
+    `iot_client_message_connect()` — declared in `src/iot_client_message.h`, a
+    header that is not installed. `iot_client.h`'s own config comment told
+    callers to invoke exactly that function, and four examples reached into the
+    private header to get it, which only compiled because they build from inside
+    the repo. An app built against the installed headers could neither connect
+    manually nor re-establish a dropped link.
+  - The default stays `false`. Flipping it would not have fixed this — a
+    reconnect loop needs `connect()` regardless of the default — and would have
+    changed behavior for every caller that zero-initializes its config,
+    including devices that deliberately use ATOP over HTTP with no broker
+    (`iot_client_init()` tears the client down and returns NULL when an
+    auto-connect fails).
+  - The four examples (`dp-management`, `ota-confirm`, `unbind-demo`,
+    `ai/rtc-tcp-client`) now use the public API and no longer include the
+    private header, so they compile the way an external consumer would.
+  - Docs corrected while making the promise public: both headers claimed a TLS
+    handshake failure "refreshes the MQTT CA certificate and retries once".
+    No such code exists — `iot_client_message_try_connect()` destroys the client
+    and returns `OPRT_TLS_HANDSHAKE_FAILED`. Cert recovery is the app's job
+    (`iot_get_ca_certificate()` + reassign `client->cacert`); a reconnect loop
+    written against the old wording retries the same doomed handshake forever
+    after a broker cert rotation.
 
 - common — coreMQTT's Error/Warn logs are routed into the SDK log facade
   (`common/core_mqtt_config.h`), so a broker's actual refusal reason is visible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,14 +78,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   straight through. Pinned by `test_closed_peer_is_reported`.
 
 - iot-client — tearing down an already-dead link no longer pushes a DISCONNECT
-  packet into a socket that cannot carry it. `mqtt_client_process()` now records
-  that the link died and `mqtt_client_disconnect()` skips only the packet, still
-  releasing the socket and buffer (clearing `connected` instead would have made
-  the teardown return early and leak both). This became worth fixing once
-  coreMQTT's errors were audible: the failed send is logged at ERROR level, so a
-  device reconnecting on a flaky link would report two errors per cycle for an
-  ordinary teardown. Not covered by a test — a just-killed peer usually absorbs
-  one more send, so the failure does not reliably reproduce against a mock.
+  packet into a socket that cannot carry it. Worth fixing once coreMQTT's errors
+  became audible: the failed send is logged at ERROR level, so a device
+  reconnecting on a flaky link reported two errors per cycle for an ordinary
+  teardown. `mqtt_client_disconnect()` skips only the packet, still releasing the
+  socket and buffer — clearing `connected` instead would have made the teardown
+  return early and leak both.
+  - Which statuses count is the whole difficulty. `MQTTBadResponse` (a malformed
+    packet) and `MQTTIllegalState` (QoS bookkeeping) are protocol faults on a
+    healthy socket; suppressing the DISCONNECT there would strand the session on
+    the broker until the 60 s keepalive expired, and since the clientId is the
+    devid, the next reconnect would race that stale session. Only
+    `MQTTRecvFailed` / `MQTTSendFailed` / `MQTTKeepAliveTimeout` qualify, and a
+    completed exchange clears the flag again — read at teardown, a latch-only
+    flag would let one transient error the caller retried past suppress the
+    DISCONNECT for the rest of a live session, reaching the same race from the
+    other end.
+  - All four coreMQTT call sites report their status: process, both subscribe
+    sites, and publish. Publish matters most — every DP report goes through it,
+    so it is the likeliest place an app discovers a dropped link.
+  - Not covered by a test — a just-killed peer usually absorbs one more send, so
+    the failing send does not reliably reproduce against a mock, and the
+    flag-clearing path needs a transient failure followed by a success that the
+    mocks cannot stage.
+
+- iot-client tests — the log-capture handlers read past the end of their stack
+  buffer. `vsnprintf` returns the length it *would* have written, so any routed
+  line longer than the local buffer made `memcpy` copy beyond it, corrupting the
+  capture with unrelated stack and able to fake or mask the very substring under
+  assertion. One coreHTTP parse error interpolates up to a whole response buffer,
+  so this was reachable. `test_connack_reason_is_logged` also asserted on the
+  bare string `MQTTServerRefused`, which coreMQTT's own routed line already
+  contains — it passed with `mqtt.c` reverted to a raw `%d`, protecting nothing.
+  It now matches the SDK's own message.
 
 - iot-client — generic ATOP call (`iot_atop_call`), for cloud interfaces the SDK
   does not wrap by name.

--- a/docs-site/docs/guides/ota-upgrade.md
+++ b/docs-site/docs/guides/ota-upgrade.md
@@ -110,7 +110,7 @@ if (rc == OPRT_OK && info.has_upgrade) {
 iot_ota_upgrade_info_free(client, &info);
 ```
 
-`ota_confirm_callback` 与 `message_callback` 一样运行在调用 `iot_client_process()` / `iot_client_message_process()` 的线程内，coreMQTT 回调返回后还要继续处理 ack 和网络缓冲。回调中只允许置位标志、释放信号量或投递工作项；不要调用 `iot_ota_check_upgrade()`、下载固件、写 flash，也不要断开或销毁 IoT client。未注册该回调时，protocol 15 会继续透传给 `message_callback`，兼容旧应用自行解析的用法。
+`ota_confirm_callback` 与 `message_callback` 一样运行在调用 `iot_client_process()` 的线程内，coreMQTT 回调返回后还要继续处理 ack 和网络缓冲。回调中只允许置位标志、释放信号量或投递工作项；不要调用 `iot_ota_check_upgrade()`、下载固件、写 flash，也不要断开或销毁 IoT client。未注册该回调时，protocol 15 会继续透传给 `message_callback`，兼容旧应用自行解析的用法。
 
 ### `iot_ota_check_upgrade` 返回的升级信息
 
@@ -233,8 +233,8 @@ iot_client_config_t iot_cfg = {
     .local_key  = DEFAULT_LOCAL_KEY,
     .region     = DEFAULT_REGION,
     .env        = DEFAULT_ENV,
-    /* mqtt_auto_connect = false: 只用 ATOP HTTP，不连 MQTT */
-    .mqtt_auto_connect = false,
+    /* 关闭自动连接：只用 ATOP HTTP，不连 MQTT */
+    .mqtt_disable_auto_connect = true,
     /* 应用固件版本：init 时自动上报，供云端 OTA 比较（NULL 用 SDK 默认） */
     .sw_ver     = desc->version,
     /* 公共 CA 证书包：ATOP HTTPS（版本上报/升级查询/状态回报）需要 */

--- a/docs-site/docs/guides/tls-cert-verification.md
+++ b/docs-site/docs/guides/tls-cert-verification.md
@@ -87,7 +87,7 @@ if (rc == OPRT_OK) {
 }
 ```
 
-> **引导阶段的“先有鸡还是先有蛋”问题：** `iot_get_ca_certificate()` 本身要先建立一次到 IoT-DNS 的 TLS 连接；若此时 `client->cacert` 仍为空，这次查询以不校验方式进行——存在引导阶段 MITM 风险。同理，`iot_client_init()` 在返回前就已完成 DNS/ATOP 的**首批连接**（若 `mqtt_auto_connect = true`——默认为 false——还包括 MQTT 首连），因此**在 init 之后再设 `client->cacert` 只对后续请求生效，无法追溯保护 init 期间的连接**。
+> **引导阶段的“先有鸡还是先有蛋”问题：** `iot_get_ca_certificate()` 本身要先建立一次到 IoT-DNS 的 TLS 连接；若此时 `client->cacert` 仍为空，这次查询以不校验方式进行——存在引导阶段 MITM 风险。同理，`iot_client_init()` 在返回前就已完成 DNS/ATOP 的**首批连接**（默认启用自动连接，因此还包括 MQTT 首连），因此**在 init 之后再设 `client->cacert` 只对后续请求生效，无法追溯保护 init 期间的连接**。
 >
 > 所以运行时获取 CA 更适合用来**取回一份 CA 加以持久化**，下次启动前通过 `cfg.cacert` 在 `iot_client_init()` **之前**传入，从第一条连接起即校验；对安全要求严格的场景，建议直接硬编码根 CA 或改用 `.cert_bundle_attach`。
 

--- a/docs-site/docs/reference/iot-client.md
+++ b/docs-site/docs/reference/iot-client.md
@@ -150,7 +150,7 @@ IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.
 | `region` | `iot_region_t` | 数据中心区域 |
 | `env` | `iot_env_t` | 环境 |
 | `mqtt_disable_tls` | `bool` | `false`（默认）使用 MQTTS，`true` 使用明文 MQTT |
-| `mqtt_auto_connect` | `bool` | `true` 初始化后自动连接 MQTT；`false`（默认）需手动调用 |
+| `mqtt_disable_auto_connect` | `bool` | `false`（默认）初始化后自动连接 MQTT；`true` 需手动调用 [`iot_client_connect()`](#iot_client_connect) |
 | `cacert` | `const char *` | CA 证书 PEM（用于 MQTT/HTTPS/IoT-DNS TLS，调用方持有，需在 client 生命周期内有效） |
 | `cert_bundle_attach` | `tls_cert_bundle_attach_fn` | 平台证书包回调（如 ESP-IDF 的 `esp_crt_bundle_attach`），NULL 表示不使用。详见 [TLS 证书验证](../guides/tls-cert-verification.md) |
 | `message_callback` | `iot_message_callback_t` | MQTT 消息回调，可为 NULL |
@@ -179,7 +179,7 @@ IoT Client 模块（CMake 目标 `tuya_iot_client`，产物 `libtuya_iot_client.
 | `timeout_ms` | `int` | 激活超时时间（毫秒） |
 | `env` | `iot_env_t` | 环境：`PROD`（默认）或 `PRE` |
 | `mqtt_disable_tls` | `bool` | TLS 开关 |
-| `mqtt_auto_connect` | `bool` | `true` 激活后自动连接 MQTT；`false`（默认）需手动调用 |
+| `mqtt_disable_auto_connect` | `bool` | `false`（默认）激活后自动连接 MQTT；`true` 需手动调用 [`iot_client_connect()`](#iot_client_connect) |
 | `cacert` | `const char *` | CA 证书 PEM（用于 MQTT/HTTPS/IoT-DNS TLS，调用方持有） |
 | `cert_bundle_attach` | `tls_cert_bundle_attach_fn` | 平台证书包回调（如 ESP-IDF 的 `esp_crt_bundle_attach`），NULL 表示不使用。详见 [TLS 证书验证](../guides/tls-cert-verification.md) |
 | `message_callback` | `iot_message_callback_t` | MQTT 消息回调 |
@@ -222,7 +222,7 @@ int iot_init_default(void);
 iot_client_t *iot_client_init(const iot_client_config_t *config);
 ```
 
-使用已有设备凭据（devid, secret_key, local_key）初始化 IoT 客户端，解析 MQTT/HTTPS 端点。当 `mqtt_auto_connect` 为 `true` 时自动建立 MQTT 连接，否则需手动调用连接。
+使用已有设备凭据（devid, secret_key, local_key）初始化 IoT 客户端，解析 MQTT/HTTPS 端点。默认会自动建立 MQTT 连接；设 `mqtt_disable_auto_connect = true` 则需手动调用 [`iot_client_connect()`](#iot_client_connect)。**注意**：自动连接失败时 `iot_client_init()` 会释放 client 并返回 `NULL`，所以开机时网络可能未就绪的设备应显式关闭自动连接、自行重连。
 
 **返回值：** 成功返回 `iot_client_t *`；失败返回 `NULL`。
 
@@ -265,6 +265,41 @@ void iot_client_deinit(iot_client_t *client);
 ```
 
 反初始化 IoT 客户端，断开 MQTT 连接，释放所有资源。
+
+---
+
+### `iot_client_connect`
+
+```c
+int iot_client_connect(iot_client_t *client);
+```
+
+连接 MQTT broker 并订阅设备入站 topic。两种场景需要调用：
+
+1. 初始化/激活时设了 `mqtt_disable_auto_connect = true`，需要自行建链；
+2. 链路断开后重连——与 [`iot_client_disconnect()`](#iot_client_disconnect) 配对用在应用自己的重连循环里。
+
+**不会自动重试，也不会自动刷新 CA 证书**：TLS 握手失败会直接返回 `OPRT_TLS_HANDSHAKE_FAILED`。证书恢复由应用负责——收到该错误码后需先用 `iot_get_ca_certificate()` 重新获取并重新赋值 `client->cacert`，再发起重连；否则 broker 证书轮换后，重连循环会对同一个注定失败的握手无限重试。可参考 `examples/posix/dp-management/` 的写法。
+
+**参数：** `client` — IoT 客户端实例（需已设置 `mqtt_url` 和 `devid`）
+
+**返回值：** `OPRT_OK` 成功；`OPRT_INVALID_PARAMETER` 表示 client / URL / devid 缺失；其他为错误码。
+
+---
+
+### `iot_client_disconnect`
+
+```c
+void iot_client_disconnect(iot_client_t *client);
+```
+
+断开 MQTT 连接并销毁 MQTT 客户端。传 `NULL` 或未连接时是安全的空操作，可重复调用。
+
+:::warning
+不要在 `iot_client_process()` 触发的回调（`message_callback` / `reset_callback` / `ota_confirm_callback`）里调用本函数或 `iot_client_deinit()`——两者都会释放 coreMQTT 接收循环当前栈上仍在使用的 mqtt client：回调返回后它还要再次解引用该上下文去回 ack、整理网络缓冲区。正确做法是置标志位，让应用主循环去断开。
+:::
+
+**参数：** `client` — IoT 客户端实例（`NULL` 安全）
 
 ---
 

--- a/docs-site/docs/tutorials/agent-trigger.md
+++ b/docs-site/docs/tutorials/agent-trigger.md
@@ -282,7 +282,7 @@ if (tai_link_up(ctx, &dc.reconn) != 0) goto cleanup;
 
 /* 上行通道：再连 MQTT，上报 DP */
 ensure_mqtt_ca(iot);
-mqtt_up(iot);                       /* iot_client_message_connect + iot_dp_report_all */
+mqtt_up(iot);                       /* iot_client_connect + iot_dp_report_all */
 report_state(iot, &o, o.battery, "trigger");
 ```
 

--- a/docs-site/docs/tutorials/pair-by-ble.md
+++ b/docs-site/docs/tutorials/pair-by-ble.md
@@ -48,10 +48,9 @@ iot_client_init_on_boarding_with_token(token)  // 6. 用 Token 激活设备
 **App 只有在检测到设备连接上涂鸦云 MQTT 通道（设备上线）后，才会判定配网成功。**
 仅完成 Token 激活、拿到 `devid` 等凭据但不连接 MQTT，App 端会显示配网失败/超时。
 
-因此务必将 `iot_on_boarding_config_t` 中的 `.mqtt_auto_connect` 设为 `true`
-（默认为 `false`），让设备在激活完成后自动连接 MQTT（示例 `main/main.c` 中
+因此这一点现在由默认行为保证——自动连接是默认开启的，无需额外配置；只要不设 `.mqtt_disable_auto_connect`，设备就会在激活完成后自动连接 MQTT（示例 `main/main.c` 中
 已如此配置）；若保持 `false`，则必须在激活成功后立即手动调用
-`iot_client_message_connect()`。
+`iot_client_connect()`。
 :::
 
 ## 关键代码
@@ -173,5 +172,5 @@ idf.py flash monitor
 - BLE 配网完成后应尽快停止 BLE 广播（`tuya_ble_nimble_stop`），避免与 WiFi 共存时的射频冲突。
 - Token 格式与其他配网方式一致：前两字符为 Region 编码。
 - 配网完成后的设备激活流程与[设备扫码配网](./scan-by-device)相同，使用 `iot_client_init_on_boarding_with_token()`。
-- 激活配置中需设置 `.mqtt_auto_connect = true`（默认为 `false`）：**App 以设备 MQTT 上线作为配网成功的判定条件**，不连接 MQTT 时 App 会显示配网失败/超时。
+- 切勿在激活配置中设 `.mqtt_disable_auto_connect = true`：**App 以设备 MQTT 上线作为配网成功的判定条件**，不连接 MQTT 时 App 会显示配网失败/超时。
 - 需确保项目正确引用了 `modules/tuya-ble/` 和 `modules/iot-client/` 组件。

--- a/docs-site/docs/tutorials/pair-overall.md
+++ b/docs-site/docs/tutorials/pair-overall.md
@@ -22,7 +22,7 @@ sidebar_position: 1
 :::warning App 配网的成功判定：设备必须上线 MQTT
 对于依赖 App 的配网方式（设备扫码、App 扫码、BLE 配网），**App 只有在检测到设备成功连接涂鸦云 MQTT 通道（设备上线）后，才会判定配网成功**。仅完成激活、拿到 `devid` 等凭据但不连接 MQTT，App 端会显示配网失败/超时——即使设备侧的激活请求本身已经返回成功。
 
-因此，配网时务必将配置中的 `.mqtt_auto_connect` 设为 `true`（默认为 `false`），让设备在激活完成后自动连接 MQTT；或在激活成功后立即手动调用 `iot_client_message_connect()`。
+配网依赖这一点，而自动连接是默认行为，无需额外配置；若你显式设了 `.mqtt_disable_auto_connect = true`，则需在激活成功后立即手动调用 `iot_client_connect()`。
 :::
 
 注：以上说的 App，可以是以下任意一种：

--- a/docs-site/docs/tutorials/scan-by-app.md
+++ b/docs-site/docs/tutorials/scan-by-app.md
@@ -81,18 +81,17 @@ iot_client_t *iot_client_init_on_boarding(const iot_on_boarding_config_t *config
 **App 只有在检测到设备连接上涂鸦云 MQTT 通道（设备上线）后，才会判定配网成功。**
 仅完成激活、拿到 `devid` 等凭据但不连接 MQTT，App 端会显示配网失败/超时。
 
-因此务必将 `iot_on_boarding_config_t` 中的 `.mqtt_auto_connect` 设为 `true`
-（默认为 `false`），让设备在激活完成后自动连接 MQTT：
+因此这一点现在由默认行为保证——自动连接是默认开启的，无需额外配置；只要不设 `.mqtt_disable_auto_connect`，设备就会在激活完成后自动连接 MQTT：
 
 ```c
 iot_on_boarding_config_t ob_config = {
     // ...
-    .mqtt_auto_connect = true,   // 激活成功后自动连接 MQTT，App 才能判定配网成功
+    // 不设 .mqtt_disable_auto_connect：默认即自动连接 MQTT，App 才能判定配网成功
 };
 ```
 
 若选择保持 `false`，则必须在激活成功后立即手动调用
-`iot_client_message_connect()`。
+`iot_client_connect()`。
 :::
 
 **与 `iot_client_init_on_boarding_with_token()` 的区别：**
@@ -123,7 +122,7 @@ iot_on_boarding_config_t ob_config = {
 
 ## 注意事项
 
-- 此方式要求设备已具备网络连接能力（Wi-Fi 或以太网），且设备必须在激活后连接涂鸦平台的 MQTT 通道——**App 以设备 MQTT 上线作为配网成功的判定条件**（见上文警告，需 `.mqtt_auto_connect = true`）。
+- 此方式要求设备已具备网络连接能力（Wi-Fi 或以太网），且设备必须在激活后连接涂鸦平台的 MQTT 通道——**App 以设备 MQTT 上线作为配网成功的判定条件**（见上文警告，切勿设 `.mqtt_disable_auto_connect = true`）。
 - `iot_client_init_on_boarding()` 会阻塞直到 App 扫码完成或超时
   （`timeout_ms` 配置），实际产品中建议在单独线程中调用。
 - 本示例使用 `qrcodegen`（nayuki 库）生成二维码，实际产品可替换为任意

--- a/docs-site/docs/tutorials/scan-by-device.md
+++ b/docs-site/docs/tutorials/scan-by-device.md
@@ -96,18 +96,17 @@ iot_client_t *iot_client_init_on_boarding_with_token(
 **App 只有在检测到设备连接上涂鸦云 MQTT 通道（设备上线）后，才会判定配网成功。**
 仅完成 Token 激活、拿到 `devid` 等凭据但不连接 MQTT，App 端会显示配网失败/超时。
 
-因此务必将 `iot_on_boarding_config_t` 中的 `.mqtt_auto_connect` 设为 `true`
-（默认为 `false`），让设备在激活完成后自动连接 MQTT：
+因此这一点现在由默认行为保证——自动连接是默认开启的，无需额外配置；只要不设 `.mqtt_disable_auto_connect`，设备就会在激活完成后自动连接 MQTT：
 
 ```c
 iot_on_boarding_config_t cfg = {
     // ...
-    .mqtt_auto_connect = true,   // 激活成功后自动连接 MQTT，App 才能判定配网成功
+    // 不设 .mqtt_disable_auto_connect：默认即自动连接 MQTT，App 才能判定配网成功
 };
 ```
 
 若选择保持 `false`，则必须在激活成功后立即手动调用
-`iot_client_message_connect()`。
+`iot_client_connect()`。
 :::
 
 **`iot_on_boarding_config_t` 主要字段：**

--- a/examples/esp-idf/ota-demo/main/main.c
+++ b/examples/esp-idf/ota-demo/main/main.c
@@ -342,7 +342,7 @@ void app_main(void)
         .region           = DEFAULT_REGION,
         .env              = DEFAULT_ENV,
         .mqtt_disable_tls = false,
-        .mqtt_auto_connect = false,
+        .mqtt_disable_auto_connect = true,
         .cert_bundle_attach = (tls_cert_bundle_attach_fn)esp_crt_bundle_attach,
         .message_callback = NULL,
         .schema           = NULL,

--- a/examples/esp-idf/pair/pair-by-ble/main/main.c
+++ b/examples/esp-idf/pair/pair-by-ble/main/main.c
@@ -167,7 +167,6 @@ static esp_err_t activate_device_with_ble_token(void)
         .timeout_ms = 120000,
         .env = PROD,
         .mqtt_disable_tls = false,
-        .mqtt_auto_connect = true,
         .cert_bundle_attach = (tls_cert_bundle_attach_fn)esp_crt_bundle_attach,
     };
 

--- a/examples/posix/ai/rtc-tcp-client/agent_trigger_demo.c
+++ b/examples/posix/ai/rtc-tcp-client/agent_trigger_demo.c
@@ -52,7 +52,6 @@
 
 #include "tuya_ai.h"
 #include "iot_client.h"
-#include "iot_client_message.h"   /* app-owned MQTT connect / process loop */
 #include "iot_dp.h"
 
 #include "demo_json.h"
@@ -645,7 +644,7 @@ static void ensure_mqtt_ca(iot_client_t *client)
  * from device-initiated reports, so this runs after every (re)connect. */
 static int mqtt_up(iot_client_t *client)
 {
-    int rc = iot_client_message_connect(client);
+    int rc = iot_client_connect(client);
     if (rc != OPRT_OK) {
         fprintf(stderr, "[iot] MQTT connect failed: %d\n", rc);
         return rc;
@@ -691,7 +690,7 @@ static int tai_link_up(tai_ctx_t *ctx, demo_reconnect_t *r)
 /* Wait `seconds` while still pumping the MQTT receive path.
  *
  * Deliberately deadline-driven rather than a fixed iteration count:
- * iot_client_message_process() DISCARDS its timeout argument (mqtt.c does
+ * iot_client_process() DISCARDS its timeout argument (mqtt.c does
  * `(void)timeout_ms;`) and blocks for up to the compile-time
  * MQTT_RECV_TIMEOUT_MS -- 1000 ms, five times the 200 we pass. Counting
  * iterations therefore overshoots by 5x on an idle link. Overshoot here is
@@ -700,7 +699,7 @@ static void pump_for(iot_client_t *iot, int seconds)
 {
     int64_t until = now_us() + (int64_t)seconds * 1000000LL;
     while (g_running && now_us() < until)
-        iot_client_message_process(iot, 200);
+        iot_client_process(iot, 200);
 }
 
 static int report_state(iot_client_t *iot, const opts_t *o,
@@ -832,7 +831,7 @@ int main(int argc, char **argv)
         .region            = DEFAULT_REGION,
         .env               = DEFAULT_ENV,
         .mqtt_disable_tls  = false,
-        .mqtt_auto_connect = false,   /* this demo owns the connect loop */
+        .mqtt_disable_auto_connect = true,   /* this demo owns the connect loop */
         .message_callback  = on_mqtt_message,
         .schema            = schema,
         .schema_id         = NULL,
@@ -987,7 +986,7 @@ int main(int argc, char **argv)
             break;
         }
 
-        int rc = iot_client_message_process(iot, 200);
+        int rc = iot_client_process(iot, 200);
         if (rc == OPRT_OK) {
             mqtt_fails = 0;
         } else {
@@ -997,7 +996,7 @@ int main(int argc, char **argv)
              * would otherwise spin here reconnecting many times a second. */
             fprintf(stderr, "[iot] MQTT link error %d; reconnecting (%d)\n",
                     rc, mqtt_fails + 1);
-            iot_client_message_disconnect(iot);
+            iot_client_disconnect(iot);
             if (++mqtt_fails >= MQTT_MAX_CONSECUTIVE_FAILS) {
                 fprintf(stderr, "[iot] giving up on the broker after %d "
                                 "consecutive failures\n", mqtt_fails);
@@ -1049,7 +1048,7 @@ cleanup:
     tai_ctx_deinit(ctx);
     pal->free(ctx_buf);
 
-    iot_client_message_disconnect(iot);
+    iot_client_disconnect(iot);
     iot_client_deinit(iot);
 
     if (dc.audio_fp) fclose(dc.audio_fp);

--- a/examples/posix/dp-management/dp_management_demo.c
+++ b/examples/posix/dp-management/dp_management_demo.c
@@ -9,13 +9,13 @@
  *
  * Lifecycle shown here:
  *   1. Read the schema (schema.json) and DP state (dp_state.json) from separate files.
- *   2. iot_client_init() with mqtt_auto_connect=false -> DP registry built from schema.
+ *   2. iot_client_init() with mqtt_disable_auto_connect=true -> DP registry built from schema.
  *      Then validate the DP state against the schema and restore it only if it
  *      fully conforms (iot_dp_validate_json), discarding a stale/mismatched file.
- *   3. Fetch the MQTT CA via IoT DNS, then iot_client_message_connect().
+ *   3. Fetch the MQTT CA via IoT DNS, then iot_client_connect().
  *   4. iot_dp_report_all() right after connect (the cloud only learns state from
  *      reports; "report on connect" is mandatory app behaviour — see the ADR).
- *   5. Loop: pump downlinks (iot_client_message_process), and on a dropped link
+ *   5. Loop: pump downlinks (iot_client_process), and on a dropped link
  *      reconnect + re-report. Periodically simulate a local change (iot_dp_set +
  *      iot_dp_report_all_dirty) and poll for a schema upgrade.
  *   6. Persist on every change via the save callback; persist a newer schema via
@@ -29,7 +29,6 @@
 #include "dp_management_demo.h"
 
 #include "iot_client.h"
-#include "iot_client_message.h"   /* manual connect/disconnect/process (app-owned loop) */
 #include "iot_dp.h"
 
 #include <stdio.h>
@@ -209,7 +208,7 @@ static void ensure_mqtt_ca(iot_client_t *client)
  * from device-initiated reports, so this runs after every (re)connect. */
 static int connect_and_report(iot_client_t *client)
 {
-    int ret = iot_client_message_connect(client);
+    int ret = iot_client_connect(client);
     if (ret != OPRT_OK) {
         fprintf(stderr, "[%s] MQTT connect failed: %d\n", TAG, ret);
         return ret;
@@ -309,7 +308,7 @@ int demo_dp_management_run(const char *devid,
         .region           = AY,      /* match your device's region/env */
         .env              = PROD,
         .mqtt_disable_tls = false,   /* mqtts */
-        .mqtt_auto_connect = false,  /* we own the connect/reconnect loop */
+        .mqtt_disable_auto_connect = true,  /* we own the connect/reconnect loop */
         .schema           = saved_schema ? saved_schema : DEFAULT_SCHEMA,
         .schema_id        = schema_id,
         .dp_state         = NULL,    /* don't auto-restore — we validate first (step 2b) */
@@ -363,11 +362,11 @@ int demo_dp_management_run(const char *devid,
     time_t last_schema = time(NULL);   /* don't poll schema immediately */
     while (g_running) {
         /* Pump the receive path; downlinks dispatch into on_dp_downlink. */
-        int rc = iot_client_message_process(client, 200);
+        int rc = iot_client_process(client, 200);
         if (rc != OPRT_OK) {
             /* No auto-reconnect in the SDK: the app reconnects, then re-reports. */
             fprintf(stderr, "[%s] link error %d; reconnecting...\n", TAG, rc);
-            iot_client_message_disconnect(client);
+            iot_client_disconnect(client);
             if (connect_and_report(client) != OPRT_OK) {
                 sleep(2);
                 continue;
@@ -400,7 +399,7 @@ int demo_dp_management_run(const char *devid,
         printf("[%s] wiping persisted state (device removed)\n", TAG);
         remove(DP_STATE_PATH);
         remove(SCHEMA_PATH);
-        iot_client_message_disconnect(client);
+        iot_client_disconnect(client);
         iot_client_deinit(client);
         printf("[%s] device reset complete — re-run pairing to activate\n", TAG);
         return 0;
@@ -416,7 +415,7 @@ int demo_dp_management_run(const char *devid,
     }
 
     /* 8. Tear down. */
-    iot_client_message_disconnect(client);
+    iot_client_disconnect(client);
     iot_client_deinit(client);
     return 0;
 }

--- a/examples/posix/ota-confirm/ota_confirm_demo.c
+++ b/examples/posix/ota-confirm/ota_confirm_demo.c
@@ -15,7 +15,6 @@
 #include "ota_demo.h"
 
 #include "iot_client.h"
-#include "iot_client_message.h"
 #include "iot_ota.h"
 
 #include <stdio.h>
@@ -59,7 +58,7 @@ static int reconnect_with_backoff(iot_client_t *client)
 
     for (int attempt = 1; attempt <= 5 && g_running; attempt++) {
         printf("[%s] reconnecting (attempt %d/5)...\n", TAG, attempt);
-        if (iot_client_message_connect(client) == OPRT_OK) {
+        if (iot_client_connect(client) == OPRT_OK) {
             printf("[%s] reconnected\n", TAG);
             return 0;
         }
@@ -165,7 +164,7 @@ int demo_ota_confirm_run(const char *devid, const char *secret_key,
         .region               = region,
         .env                  = PROD,
         .mqtt_disable_tls     = false,
-        .mqtt_auto_connect    = false,
+        .mqtt_disable_auto_connect = true,
         .message_callback     = on_message,
         .ota_confirm_callback = on_ota_confirm,
         .ota_confirm_user_data = &state,
@@ -183,7 +182,7 @@ int demo_ota_confirm_run(const char *devid, const char *secret_key,
 
     printf("[%s] client initialized (devid=%s, region=%s)\n",
            TAG, client->devid, region_name);
-    int rc = iot_client_message_connect(client);
+    int rc = iot_client_connect(client);
     if (rc != OPRT_OK) {
         fprintf(stderr, "[%s] MQTT connect failed: %d\n", TAG, rc);
         iot_client_deinit(client);
@@ -198,7 +197,7 @@ int demo_ota_confirm_run(const char *devid, const char *secret_key,
         rc = iot_client_process(client, 200);
         if (rc != OPRT_OK) {
             fprintf(stderr, "[%s] MQTT process failed: %d\n", TAG, rc);
-            iot_client_message_disconnect(client);
+            iot_client_disconnect(client);
             if (reconnect_with_backoff(client) != 0) {
                 fprintf(stderr, "[%s] give up after reconnect failures\n", TAG);
                 result = 1;
@@ -218,7 +217,7 @@ int demo_ota_confirm_run(const char *devid, const char *secret_key,
     }
 
 out:
-    iot_client_message_disconnect(client);
+    iot_client_disconnect(client);
     iot_client_deinit(client);
     return result;
 }

--- a/examples/posix/ota-demo/ota_demo.c
+++ b/examples/posix/ota-demo/ota_demo.c
@@ -142,7 +142,7 @@ int demo_ota_run(const char *devid, const char *secret_key, const char *local_ke
         .region            = AY,
         .env               = PROD,
         .mqtt_disable_tls  = false,
-        .mqtt_auto_connect = false,
+        .mqtt_disable_auto_connect = true,
         .sw_ver            = sw_ver,
     };
     strncpy(cfg.devid,      devid,      sizeof(cfg.devid) - 1);

--- a/examples/posix/pair/unbind-demo/unbind_demo.c
+++ b/examples/posix/pair/unbind-demo/unbind_demo.c
@@ -17,7 +17,6 @@
 #include "unbind_demo.h"
 
 #include "iot_client.h"
-#include "iot_client_message.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -69,7 +68,7 @@ int demo_unbind_run(const char *devid, const char *secret_key,
         .region            = AY,
         .env               = PROD,
         .mqtt_disable_tls  = false,
-        .mqtt_auto_connect = false,
+        .mqtt_disable_auto_connect = true,
         .reset_callback    = on_reset,
         .message_callback  = on_message,
     };
@@ -84,7 +83,7 @@ int demo_unbind_run(const char *devid, const char *secret_key,
     }
     printf("[%s] client initialized (devid=%s)\n", TAG, client->devid);
 
-    int ret = iot_client_message_connect(client);
+    int ret = iot_client_connect(client);
     if (ret != OPRT_OK) {
         fprintf(stderr, "[%s] MQTT connect failed: %d\n", TAG, ret);
         iot_client_deinit(client);
@@ -95,12 +94,12 @@ int demo_unbind_run(const char *devid, const char *secret_key,
     printf("[%s] (Ctrl-C to quit without unbinding)\n\n", TAG);
 
     while (g_running) {
-        int rc = iot_client_message_process(client, 200);
+        int rc = iot_client_process(client, 200);
         if (rc != OPRT_OK && g_running) {
             fprintf(stderr, "[%s] link error %d; reconnecting...\n", TAG, rc);
-            iot_client_message_disconnect(client);
+            iot_client_disconnect(client);
             sleep(2);
-            ret = iot_client_message_connect(client);
+            ret = iot_client_connect(client);
             if (ret != OPRT_OK) {
                 fprintf(stderr, "[%s] reconnect failed: %d\n", TAG, ret);
                 continue;
@@ -110,7 +109,7 @@ int demo_unbind_run(const char *devid, const char *secret_key,
     }
 
     printf("\n[%s] shutting down\n", TAG);
-    iot_client_message_disconnect(client);
+    iot_client_disconnect(client);
     iot_client_deinit(client);
     return 0;
 }

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -102,7 +102,7 @@ typedef enum {
  * Must NOT block (it runs inside the MQTT process loop). The recommended
  * action is to set a flag and let the app loop tear down (disconnect → wipe
  * persisted credentials/schema/DP state → restart on-boarding). Do NOT call
- * iot_client_deinit() or iot_client_message_disconnect() from within this
+ * iot_client_deinit() or iot_client_disconnect() from within this
  * callback — both free the mqtt client that the coreMQTT receive loop is
  * still using on this very stack (it dereferences the context again to send
  * acks and compact the network buffer after the callback returns).
@@ -145,7 +145,7 @@ typedef struct {
     iot_region_t region;           // Region
     iot_env_t env;                 // Environment
     bool mqtt_disable_tls;         // false = mqtts (TLS, default), true = mqtt (TCP)
-    bool mqtt_auto_connect;        // true = connect MQTT after init/activation; false (default) = caller invokes iot_client_message_connect() manually
+    bool mqtt_disable_auto_connect; // false (default) = connect MQTT after init/activation; true = caller invokes iot_client_connect() manually
     const char *cacert;            // CA cert for all TLS (MQTT/HTTPS/IoT-DNS) (PEM, caller-owned, must outlive client)
     tls_cert_bundle_attach_fn cert_bundle_attach; // Platform cert-bundle callback (NULL = none)
     iot_message_callback_t message_callback; // MQTT message callback
@@ -175,7 +175,7 @@ typedef struct {
     int timeout_ms;
     iot_env_t env;                 // PROD (default) or PRE
     bool mqtt_disable_tls;         // false = mqtts (TLS, default), true = mqtt (TCP)
-    bool mqtt_auto_connect;        // true = connect MQTT after init/activation; false (default) = caller invokes iot_client_message_connect() manually
+    bool mqtt_disable_auto_connect; // false (default) = connect MQTT after init/activation; true = caller invokes iot_client_connect() manually
     const char *cacert;            // CA cert for all TLS (MQTT/HTTPS/IoT-DNS) (PEM, caller-owned, must outlive client)
     tls_cert_bundle_attach_fn cert_bundle_attach; // Platform cert-bundle callback (NULL = none)
     iot_message_callback_t message_callback; // MQTT message callback
@@ -274,6 +274,36 @@ IOT_API iot_client_t *iot_client_init_on_boarding_with_token(const iot_on_boardi
  * @param client Pointer to iot_client_t instance (NULL is safe)
  */
 IOT_API void iot_client_deinit(iot_client_t *client);
+
+/**
+ * @brief Connect to the MQTT broker and subscribe to the device's inbound topic.
+ *
+ * Needed on two paths: after an init/activation that set `mqtt_disable_auto_connect`
+ * false, and to re-establish a link that dropped (pair it with
+ * iot_client_disconnect() in the app's reconnect loop).
+ *
+ * There is no automatic retry and no automatic CA refresh: a TLS failure comes
+ * straight back as OPRT_TLS_HANDSHAKE_FAILED. Cert recovery belongs to the app
+ * -- on that error code, re-fetch the CA with iot_get_ca_certificate() and
+ * reassign client->cacert before reconnecting, or a reconnect loop will retry
+ * the same doomed handshake forever after a broker cert rotation. See
+ * examples/posix/dp-management/ for the shape of that loop.
+ *
+ * @param client Pointer to iot_client_t instance (must have mqtt_url and devid set)
+ * @return OPRT_OK on success, OPRT_INVALID_PARAMETER if client/url/devid is missing
+ */
+IOT_API int iot_client_connect(iot_client_t *client);
+
+/**
+ * @brief Disconnect from the MQTT broker and destroy the MQTT client.
+ *
+ * Safe to call with NULL or when not connected (no-op). Must NOT be called
+ * from inside a callback fired by iot_client_process() — see
+ * iot_reset_callback_t for why.
+ *
+ * @param client Pointer to iot_client_t instance (NULL is safe)
+ */
+IOT_API void iot_client_disconnect(iot_client_t *client);
 
 /**
  * @brief Process MQTT events (call this in a loop to receive messages)

--- a/modules/iot-client/src/iot_client.c
+++ b/modules/iot-client/src/iot_client.c
@@ -233,7 +233,7 @@ IOT_API iot_client_t *iot_client_init(const iot_client_config_t *config)
         iot_client_dns_resolve(client);
     }
 
-    if (client->mqtt_url[0] != '\0' && config->mqtt_auto_connect) {
+    if (client->mqtt_url[0] != '\0' && !config->mqtt_disable_auto_connect) {
         int ret = iot_client_message_connect(client);
         if (ret != OPRT_OK) {
             log_error("MQTT connect failed: %d", ret);
@@ -369,7 +369,7 @@ IOT_API iot_client_t *iot_client_init_on_boarding(const iot_on_boarding_config_t
     client_config.region = ob_resp.region;
     client_config.env = ob_resp.env;
     client_config.mqtt_disable_tls = config->mqtt_disable_tls;
-    client_config.mqtt_auto_connect = config->mqtt_auto_connect;
+    client_config.mqtt_disable_auto_connect = config->mqtt_disable_auto_connect;
     client_config.cacert = config->cacert;
     client_config.cert_bundle_attach = config->cert_bundle_attach;
     client_config.message_callback = config->message_callback;
@@ -465,7 +465,7 @@ IOT_API iot_client_t *iot_client_init_on_boarding_with_token(const iot_on_boardi
     client_config.region = ob_resp.region;
     client_config.env = ob_resp.env;
     client_config.mqtt_disable_tls = config->mqtt_disable_tls;
-    client_config.mqtt_auto_connect = config->mqtt_auto_connect;
+    client_config.mqtt_disable_auto_connect = config->mqtt_disable_auto_connect;
     client_config.cacert = config->cacert;
     client_config.cert_bundle_attach = config->cert_bundle_attach;
     client_config.message_callback = config->message_callback;
@@ -532,6 +532,22 @@ IOT_API int iot_client_get_session_token(iot_client_t *client, const char *agent
     token[resp_token_len] = '\0';
     client->pal->free(resp.token);
     return OPRT_OK;
+}
+
+IOT_API int iot_client_connect(iot_client_t *client)
+{
+    /* No NULL guard, like its neighbour below: iot_client_message_connect()
+     * already rejects NULL (along with a missing url/devid) with the same
+     * OPRT_INVALID_PARAMETER, so a guard here could only duplicate it. */
+    return iot_client_message_connect(client);
+}
+
+IOT_API void iot_client_disconnect(iot_client_t *client)
+{
+    /* No NULL guard, unlike its neighbours: this one returns void, so the
+     * guard could only swallow the argument -- and the callee is already
+     * documented NULL-safe and no-op when not connected. */
+    iot_client_message_disconnect(client);
 }
 
 IOT_API int iot_client_process(iot_client_t *client, uint32_t timeout_ms)

--- a/modules/iot-client/src/iot_client_message.c
+++ b/modules/iot-client/src/iot_client_message.c
@@ -207,6 +207,19 @@ int iot_client_message_connect(iot_client_t *client)
         return OPRT_INVALID_PARAMETER;
     }
 
+    /* Already connected is success, not a reason to build a second link.
+     * iot_client_message_try_connect() assigns client->mqtt unconditionally, so
+     * without this the previous mqtt client, its packet buffer and its open
+     * socket leak with no handle left to free them. Easy to hit now that
+     * iot_client_connect() is public and documented as *the* way to bring the
+     * link up: an app that also left mqtt_auto_connect true calls it on an
+     * already-connected client. To force a fresh link, disconnect first. */
+    if (client->mqtt) {
+        log_warn("iot_client_message_connect: already connected, ignoring "
+                 "(call iot_client_disconnect() first to reconnect)");
+        return OPRT_OK;
+    }
+
     return iot_client_message_try_connect(client);
 }
 

--- a/modules/iot-client/src/iot_client_message.h
+++ b/modules/iot-client/src/iot_client_message.h
@@ -12,8 +12,10 @@
 /**
  * @brief Connect to the MQTT broker and subscribe to the device's inbound topic.
  *
- * On TLS handshake failure, automatically refreshes the MQTT CA certificate
- * and retries once.
+ * Connects once, with no retry and no CA refresh: a TLS failure is returned as
+ * OPRT_TLS_HANDSHAKE_FAILED for the caller to recover from. See
+ * iot_client_connect() in iot_client.h -- the public entry point -- for what
+ * that recovery has to do.
  *
  * @param client  IoT client (must have mqtt_url and devid set)
  * @return OPRT_OK on success, OPRT_INVALID_PARAMETER if client/url/devid is missing

--- a/modules/iot-client/src/mqtt.c
+++ b/modules/iot-client/src/mqtt.c
@@ -387,6 +387,31 @@ static void release_mqtt_buffer(mqtt_client *client) {
     client->fixed_buffer.size = 0;
 }
 
+/* Record what an MQTTStatus says about the transport underneath, for the
+ * DISCONNECT-suppression check in mqtt_client_disconnect().
+ *
+ * Only these three mean the socket is gone. MQTTBadResponse (a malformed packet
+ * arrived) and MQTTIllegalState (QoS bookkeeping hit an impossible state) are
+ * protocol faults on a perfectly healthy socket -- suppressing the DISCONNECT
+ * for those strands the session on the broker until the 60 s keepalive expires,
+ * and since the clientId is the devid, the next reconnect races that stale
+ * session.
+ *
+ * A completed exchange clears the flag again, which matters just as much: the
+ * flag is read at teardown, possibly long after the failure, so latch-only
+ * would let one transient error the caller retried past suppress the DISCONNECT
+ * for the rest of a demonstrably live session -- the same race from the other
+ * end. Every call site reports its status, success included. */
+static void mqtt_note_transport_state(mqtt_client *client, MQTTStatus_t status)
+{
+    if (status == MQTTRecvFailed || status == MQTTSendFailed ||
+        status == MQTTKeepAliveTimeout) {
+        client->link_dead = true;
+    } else if (status == MQTTSuccess || status == MQTTNeedMoreBytes) {
+        client->link_dead = false;
+    }
+}
+
 /* Unwind a half-built connection: drop the transport, hand back the MQTT buffer.
  * Shared by the three failure points that sit between a live socket and a usable
  * MQTT session (Init, InitStatefulQoS, Connect), which were three byte-identical
@@ -515,6 +540,7 @@ int mqtt_client_subscribe(mqtt_client *client) {
 
     uint16_t packet_id = MQTT_GetPacketId(&client->mqtt_context);
     MQTTStatus_t status = MQTT_Subscribe(&client->mqtt_context, &subscribe_info, 1, packet_id);
+    mqtt_note_transport_state(client, status);
 
     if (status != MQTTSuccess) {
         log_error("MQTT_Subscribe failed: %s (%d)", MQTT_Status_strerror(status), status);
@@ -526,6 +552,7 @@ int mqtt_client_subscribe(mqtt_client *client) {
     int retries = 50;
     while (retries-- > 0) {
         status = MQTT_ProcessLoop(&client->mqtt_context);
+        mqtt_note_transport_state(client, status);
         if (status == MQTTSuccess) {
             if (client->suback_status == 0) {
                 log_info("Successfully subscribed to topic: %s", client->subscribe_topic);
@@ -566,6 +593,7 @@ int mqtt_client_publish(mqtt_client *client, const char *topic,
 
     MQTTStatus_t status = MQTT_Publish(&client->mqtt_context, &publish_info,
                                       MQTT_GetPacketId(&client->mqtt_context));
+    mqtt_note_transport_state(client, status);
 
     if (status != MQTTSuccess) {
         log_error("MQTT_Publish failed: %s (%d)", MQTT_Status_strerror(status), status);
@@ -588,9 +616,10 @@ int mqtt_client_process(mqtt_client *client, uint32_t timeout_ms) {
 
     MQTTStatus_t status = MQTT_ProcessLoop(&client->mqtt_context);
 
+    mqtt_note_transport_state(client, status);
+
     if (status != MQTTSuccess && status != MQTTNeedMoreBytes) {
         log_error("MQTT_ProcessLoop failed: %s (%d)", MQTT_Status_strerror(status), status);
-        client->link_dead = true;
         return OPRT_COMMUNICATION_ERROR;
     }
 

--- a/modules/iot-client/test/iot_atop_call_test.c
+++ b/modules/iot-client/test/iot_atop_call_test.c
@@ -492,9 +492,14 @@ static void http_capture_handler(log_level_t level, const char *fmt, va_list arg
     char line[1024];
     int n = vsnprintf(line, sizeof(line), fmt, copy);
     va_end(copy);
-    if (n > 0 && http_log_capture_len + (size_t)n + 1 < sizeof(http_log_capture)) {
-        memcpy(http_log_capture + http_log_capture_len, line, (size_t)n);
-        http_log_capture_len += (size_t)n;
+        /* vsnprintf returns the length it WOULD have written, so it exceeds
+         * the buffer on a truncated message -- copying `n` reads past `line`.
+         * Routed lines do get long: one coreHTTP parse error interpolates up to
+         * a whole response buffer. */
+    size_t len = (n > 0 && (size_t)n < sizeof(line)) ? (size_t)n : sizeof(line) - 1;
+    if (n > 0 && http_log_capture_len + len + 1 < sizeof(http_log_capture)) {
+        memcpy(http_log_capture + http_log_capture_len, line, len);
+        http_log_capture_len += len;
         http_log_capture[http_log_capture_len++] = '\n';
         http_log_capture[http_log_capture_len] = '\0';
     }

--- a/modules/iot-client/test/iot_client_message_test.c
+++ b/modules/iot-client/test/iot_client_message_test.c
@@ -442,16 +442,16 @@ static int test_encrypted_message(void)
     return result;
 }
 
-/* ---------- Test 5: iot_client_init with mqtt_auto_connect=true must short-circuit when no mqtt_url ---------- */
+/* ---------- Test 5: auto-connect (the default) must short-circuit when there is no mqtt_url ---------- */
 
 static int test_iot_client_init_autoconnect_no_url(void)
 {
     /* Empty devid skips DNS resolution, so mqtt_url stays NULL. The new
-     * auto-connect branch (`client->mqtt_url && config->mqtt_auto_connect`)
+     * auto-connect branch (`client->mqtt_url && !config->mqtt_disable_auto_connect`)
      * must safely short-circuit — returning a usable, disconnected client
      * instead of crashing or attempting a connect with NULL URL. */
     iot_client_config_t cfg = {0};
-    cfg.mqtt_auto_connect = true;
+    /* Nothing set: auto-connect is the default. */
 
     iot_client_t *client = iot_client_init(&cfg);
     if (!client) {
@@ -472,12 +472,12 @@ static int test_iot_client_init_autoconnect_no_url(void)
     return result;
 }
 
-/* ---------- Test 6: iot_client_init with mqtt_auto_connect=false also stays disconnected ---------- */
+/* ---------- Test 6: iot_client_init with auto-connect disabled also stays disconnected ---------- */
 
 static int test_iot_client_init_no_autoconnect(void)
 {
     iot_client_config_t cfg = {0};
-    cfg.mqtt_auto_connect = false;
+    cfg.mqtt_disable_auto_connect = true;
 
     iot_client_t *client = iot_client_init(&cfg);
     if (!client) {
@@ -518,6 +518,113 @@ static int test_iot_client_init_copies_ota_confirm_config(void)
         result = -1;
     }
     iot_client_deinit(client);
+    return result;
+}
+
+/* [8] the public connect/disconnect wrappers reach the message layer.
+ *
+ * They exist because iot_client_message_connect() lives in a src-private
+ * header: with mqtt_disable_auto_connect set, an app built against the
+ * installed headers had no way to bring the link up, and no way to
+ * re-establish a dropped one -- while iot_client.h's own config comment told
+ * it to call exactly that function. A NULL-client check alone would pass
+ * against an empty stub too, so the forwarding is pinned on a verdict only
+ * the callee reaches: the missing mqtt_url/devid rejection. */
+static int test_public_connect_wrappers_forward(void)
+{
+    int result = 0;
+
+    if (iot_client_connect(NULL) != OPRT_INVALID_PARAMETER) {
+        printf("  iot_client_connect(NULL) must return OPRT_INVALID_PARAMETER\n");
+        result = -1;
+    }
+    iot_client_disconnect(NULL);   /* must be a safe no-op, per the header */
+
+    /* Empty devid skips DNS, so mqtt_url stays unset. That state is rejected
+     * only inside iot_client_message_connect(), and without ever opening a
+     * socket -- so the verdict below proves the call was forwarded. */
+    iot_client_config_t cfg = {0};
+    cfg.mqtt_disable_auto_connect = true;
+    iot_client_t *client = iot_client_init(&cfg);
+    if (!client) {
+        printf("  iot_client_init returned NULL\n");
+        return -1;
+    }
+
+    if (iot_client_connect(client) != OPRT_INVALID_PARAMETER) {
+        printf("  connect on a client with no mqtt_url/devid should be rejected\n");
+        result = -1;
+    }
+    if (iot_client_connect(client) != iot_client_message_connect(client)) {
+        printf("  public wrapper disagrees with the private entry point\n");
+        result = -1;
+    }
+
+    /* Never-connected client, disconnected twice: no-op both times. */
+    iot_client_disconnect(client);
+    iot_client_disconnect(client);
+    if (client->mqtt != NULL) {
+        printf("  expected mqtt=NULL after disconnect on an unconnected client\n");
+        result = -1;
+    }
+
+    iot_client_deinit(client);
+    return result;
+}
+
+/* [9] connect on an already-connected client must not build a second link.
+ *
+ * iot_client_message_try_connect() assigns client->mqtt unconditionally, so a
+ * second pass overwrites the handle and leaks the previous mqtt client, its
+ * packet buffer and its open socket -- with nothing left pointing at them. Easy
+ * to reach now that iot_client_connect() is public and documented as the way to
+ * bring the link up: an app that also left auto-connect enabled calls it on a
+ * client that is already connected.
+ *
+ * Asserting the handle is unchanged is what pins it; the leak itself shows up
+ * under test/run_leaks_check.sh. */
+static int test_connect_twice_keeps_one_link(void)
+{
+    const pal_t *pal = get_default_pal();
+    iot_client_t *client = (iot_client_t *)pal->malloc(sizeof(iot_client_t));
+    if (!client) return -1;
+    memset(client, 0, sizeof(iot_client_t));
+    client->pal = pal;
+    strncpy((char *)client->devid, TEST_DEVID, sizeof(client->devid) - 1);
+    strncpy((char *)client->secret_key, TEST_SECRET_KEY, sizeof(client->secret_key) - 1);
+    strncpy((char *)client->local_key, TEST_LOCAL_KEY, sizeof(client->local_key) - 1);
+    snprintf(client->mqtt_url, sizeof(client->mqtt_url), "%s", TEST_MQTT_URL);
+    client->cacert = g_cacert;
+
+    int result = 0;
+    if (iot_client_connect(client) != OPRT_OK) {
+        printf("  first connect failed\n");
+        pal->free(client);
+        return -1;
+    }
+    void *first = client->mqtt;
+    if (first == NULL) {
+        printf("  connect reported success but left mqtt NULL\n");
+        result = -1;
+    }
+
+    /* Second call: success, and the same link. */
+    if (iot_client_connect(client) != OPRT_OK) {
+        printf("  second connect should report OPRT_OK (already connected)\n");
+        result = -1;
+    }
+    if (client->mqtt != first) {
+        printf("  second connect replaced the mqtt handle -- the first one leaked\n");
+        result = -1;
+    }
+
+    iot_client_disconnect(client);
+    if (client->mqtt != NULL) {
+        printf("  disconnect left mqtt non-NULL\n");
+        result = -1;
+    }
+    client->mqtt_url[0] = '\0';
+    pal->free(client);
     return result;
 }
 
@@ -814,10 +921,12 @@ int main(void)
     RUN_TEST(test_invalid_format_message);
     RUN_TEST(test_decrypt_fail_wrong_key);
 
-    /* iot_client_init + mqtt_auto_connect (no mocks needed: empty devid skips DNS) */
+    /* iot_client_init + auto-connect (no mocks needed: empty devid skips DNS) */
     RUN_TEST(test_iot_client_init_autoconnect_no_url);
     RUN_TEST(test_iot_client_init_no_autoconnect);
     RUN_TEST(test_iot_client_init_copies_ota_confirm_config);
+    RUN_TEST(test_public_connect_wrappers_forward);
+    RUN_TEST(test_connect_twice_keeps_one_link);
 
     /* Reset callback tests (network-free, no mocks needed) */
     RUN_TEST(test_reset_unbind);

--- a/modules/iot-client/test/mqtt_test.c
+++ b/modules/iot-client/test/mqtt_test.c
@@ -407,9 +407,14 @@ static void capture_log_handler(log_level_t level, const char *fmt, va_list args
     char line[512];
     int n = vsnprintf(line, sizeof(line), fmt, copy);
     va_end(copy);
-    if (n > 0 && log_capture_len + (size_t)n + 1 < sizeof(log_capture)) {
-        memcpy(log_capture + log_capture_len, line, (size_t)n);
-        log_capture_len += (size_t)n;
+        /* vsnprintf returns the length it WOULD have written, so it exceeds
+         * the buffer on a truncated message -- copying `n` reads past `line`.
+         * Routed lines do get long: one coreHTTP parse error interpolates up to
+         * a whole response buffer. */
+    size_t len = (n > 0 && (size_t)n < sizeof(line)) ? (size_t)n : sizeof(line) - 1;
+    if (n > 0 && log_capture_len + len + 1 < sizeof(log_capture)) {
+        memcpy(log_capture + log_capture_len, line, len);
+        log_capture_len += len;
         log_capture[log_capture_len++] = '\n';
         log_capture[log_capture_len] = '\0';
     }
@@ -464,9 +469,12 @@ static int test_connack_reason_is_logged(void)
         printf("  is MQTT_DO_NOT_USE_CUSTOM_CONFIG back, or common/ off coreMQTT's include path?\n");
         result = -1;
     }
-    /* And our own line still names the status symbolically. */
-    if (strstr(log_capture, "MQTTServerRefused") == NULL) {
-        printf("  expected the symbolic status name in the SDK log line\n");
+    /* And the SDK's own line names the status symbolically. This must match the
+     * message too, not just the enum name: coreMQTT itself logs "MQTT connection
+     * failed with status = MQTTServerRefused", captured by the same handler, so a
+     * bare search for the enum name passes even with mqtt.c back on a raw "%d". */
+    if (strstr(log_capture, "MQTT_Connect failed: MQTTServerRefused") == NULL) {
+        printf("  the SDK's own log line lost the symbolic status name\n");
         result = -1;
     }
 


### PR DESCRIPTION
## ⚠️ Breaking change

`mqtt_auto_connect` is replaced by **`mqtt_disable_auto_connect`** on both
`iot_client_config_t` and `iot_on_boarding_config_t`.

```c
.mqtt_auto_connect = false,   →   .mqtt_disable_auto_connect = true,
.mqtt_auto_connect = true,    →   (delete the line — it is the default now)
```

Existing code breaks at **compile time** rather than silently changing
behaviour. That is the reason for renaming instead of flipping the value.

## Why

Bringing the MQTT link up was not something an app could do. The only entry
point was `iot_client_message_connect()`, declared in
`src/iot_client_message.h` — a header that is not installed. Meanwhile
`iot_client.h`'s own config comment told callers to invoke exactly that
function, and four examples reached into the private header to get it, compiling
only because they build from inside the repo.

## Two changes, because either alone leaves the API awkward

**`iot_client_connect()` / `iot_client_disconnect()` are now public** — thin
wrappers over the message layer, same shape as the existing
`iot_client_process()` / `iot_client_publish()` pair. A reconnect loop needs them
regardless of the default, which is why publishing them is not made redundant by
the second change.

**Auto-connect is on by default.** The rename is what makes that expressible at
all: a zero-initialized struct gives a `bool` `false`, so a field named
`mqtt_auto_connect` can only ever default to off. Reversing the sense follows
`mqtt_disable_tls`, which already reads "false (default) = TLS on" in the same
two structs.

## The failure path is unchanged — read this if your device boots offline

A failed auto-connect still releases the client and returns `NULL` from
`iot_client_init()`. **That now applies by default.** A device whose network may
not be up at boot, or one that only speaks ATOP over HTTP with no broker at all
(`examples/posix/ota-demo`), must set `mqtt_disable_auto_connect` and drive the
link itself — otherwise it fails to initialize instead of coming up and
retrying.

## A latent leak, fixed here

Connecting an already-connected client built a second link and orphaned the
first: `iot_client_message_try_connect()` assigns `client->mqtt`
unconditionally, so the previous mqtt client, its packet buffer and its open
socket were left with nothing pointing at them. Reachable precisely because this
API is now public *and* connects by default — an app calling it on a live client
is the expected case, not a mistake. A second call is now success without
rebuilding; disconnect first to force a fresh link. The guard sits in the private
entry point so every path is covered, including init's auto-connect.

## A false promise removed

Both headers claimed a TLS handshake failure "refreshes the MQTT CA certificate
and retries once". No such code exists — `try_connect()` destroys the client and
returns `OPRT_TLS_HANDSHAKE_FAILED`. Cert recovery is the app's job
(`iot_get_ca_certificate()` + reassign `client->cacert`); a reconnect loop
written against the old wording retries the same doomed handshake forever after a
broker cert rotation.

## Verification

- Full build clean; `ctest --timeout 180` 13/13; `iot_message_test` 18/18 (2 new)
- The posix examples that configure this field build against the new API
- `test_connect_twice_keeps_one_link` checked to bite: reverting the guard drops
  `iot_message_test` to 17/18

## The new default has no test coverage

Worth stating plainly for something every caller inherits: both auto-connect
tests use an empty devid, so `mqtt_url` stays empty and the branch
short-circuits **before the flag is read**. I inverted the predicate and
`iot_message_test` still passed 18/18. Proving the default would need a DNS mock
and a broker mock in one suite, which none has today.
