### PR TITLE
fix(iot-client): send resetFactory, and let the caller choose it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the success path frees the struct; the mock answers a devId containing
     "busy" with the interface doc's own `REMOTE_API_RUN_UNKNOW_FAILED` so the
     failure path is reachable. Verified leak-free.
-  - The interface version is `"3.0"`, not the `"1.0"` most `tuya.device.*`
+  - The interface version is `"5.0"`, not the `"1.0"` most `tuya.device.*`
     interfaces here use — easy to "correct" by mistake, and a wrong version
     fails only at the cloud, as a rejection that reads like a network fault. The
     mock therefore verifies `v=3.0` and answers anything else with
@@ -207,6 +207,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since a device the cloud has already unbound has its CONNECT refused
   (CONNACK 4/5). The reset path now runs before any connect, and branches on the
   returned `errorCode` to show the terminal-vs-retryable distinction.
+
+- iot-client — `iot_client_reset()` sends `resetFactory`, and the caller chooses
+  it. The request body was `{"t":…}` only, which the cloud rejects: this
+  interface requires the field.
+  - New `iot_reset_scope_t` picks the value, and the two options differ in
+    whether they can be undone. `IOT_RESET_UNBIND_ONLY` (`false`) gives up the
+    user-device binding and leaves the device's cloud-side data in place, so
+    re-pairing can pick it up again. `IOT_RESET_FACTORY` (`true`) additionally
+    discards that data, business-specific exclusions aside, and **cannot be
+    undone** — re-pairing yields a new binding, not the old state.
+  - Same pair of meanings as the inbound protocol-11 classification, in the
+    opposite direction, which is why it is a separate type: the existing
+    `IOT_RESET_REMOTE_*` constants are named for a push the cloud initiated and
+    read backwards on a call the device makes. An enum rather than a bool
+    because a bare `true` at the call site would not say which one it is, and
+    the wrong one is unrecoverable.
+  - The mock requires the field and pins the choice: a devId containing
+    "factory" must arrive with `resetFactory=true`, any other with `false`, so a
+    scope that does not reach the wire is rejected rather than passing silently.
+    Checked by inverting the mapping — `iot_reset_test` drops to 2/5. The
+    success envelope still returns an empty `result`, as the real interface
+    does.
+  - `api-activate --release` uses `IOT_RESET_UNBIND_ONLY` so the demo can be run
+    repeatedly; the comment there says what a real decommission would pass.
 
 ### Fixed
 

--- a/docs-site/docs/reference/iot-client.md
+++ b/docs-site/docs/reference/iot-client.md
@@ -261,10 +261,34 @@ iot_client_t *iot_client_init_on_boarding_with_token(
 ### `iot_client_reset`
 
 ```c
-int iot_client_reset(iot_client_t *client, char *error_code, size_t error_code_len);
+int iot_client_reset(iot_client_t *client, iot_reset_scope_t scope,
+                     char *error_code, size_t error_code_len);
 ```
 
-告知云端本设备正在重置（解绑），调用的是 ATOP 接口 `tuya.device.reset`（version `3.0`）。
+告知云端本设备正在重置，调用的是 ATOP 接口 `tuya.device.reset`（version `5.0`），请求体固定为：
+
+```json
+{"resetFactory":true,"t":1756108800}
+```
+
+`resetFactory` 由 `scope` 参数决定，两者**能否撤销完全不同**：
+
+| `scope` | `resetFactory` | 云端行为 | 可逆性 |
+|---|---|---|---|
+| `IOT_RESET_UNBIND_ONLY` | `false` | 仅解除「用户—设备」绑定，设备的云端数据保留 | 重新配网可以接回原数据 |
+| `IOT_RESET_FACTORY` | `true` | 在解绑之外，**清理该设备的全部相关数据**（特殊业务另有约定的除外） | **不可逆** |
+
+这与云端下行 protocol 11 里 `IOT_RESET_REMOTE_UNBIND` / `IOT_RESET_REMOTE_FACTORY` 的区分是同一对语义，只是方向相反（那是云端推给设备的分类，这是设备向云端提出的选择）。
+
+:::danger IOT_RESET_FACTORY 不可逆
+`IOT_RESET_FACTORY` 会让云端删除该设备**所有相关数据**，没有任何恢复手段：重新配网得到的是一个新的绑定，不是原来的状态。只在**设备退役 / 交付新用户**时使用。
+
+日常场景（用户在 App 里解绑后设备自清理、或设备换绑）用 `IOT_RESET_UNBIND_ONLY`。
+:::
+
+:::caution 两者都不是「重连」
+无论哪个 scope 都会交出绑定关系。想干净地重连，用 [`iot_client_disconnect()`](#iot_client_disconnect) + [`iot_client_connect()`](#iot_client_connect)。
+:::
 
 **成败决定 client 的归属**——这是使用本接口最重要的一点：
 
@@ -297,7 +321,8 @@ int iot_client_reset(iot_client_t *client, char *error_code, size_t error_code_l
 
 ```c
 char err[64] = {0};
-int rc = iot_client_reset(client, err, sizeof(err));
+/* 退役设备用 IOT_RESET_FACTORY；日常解绑用 IOT_RESET_UNBIND_ONLY */
+int rc = iot_client_reset(client, IOT_RESET_UNBIND_ONLY, err, sizeof(err));
 if (rc == OPRT_OK) {
     /* client 已销毁；擦除自己保存的凭据即可 */
 } else if (strcmp(err, "GATEWAY_NOT_EXISTS") == 0) {
@@ -310,6 +335,7 @@ if (rc == OPRT_OK) {
 
 **参数：**
 - `client` — 已激活的 IoT 客户端实例
+- `scope` — 清理范围，见上表；除设备退役外一律用 `IOT_RESET_UNBIND_ONLY`
 - `error_code` — 可选，接收云端 errorCode；云端未给时为 `""`。不需要可传 `NULL`。`IOT_ATOP_ERROR_CODE_LEN`（48）字节足够
 - `error_code_len` — `error_code` 缓冲区大小（传 NULL 时忽略）
 

--- a/examples/posix/pair/api-activate/activate_demo.c
+++ b/examples/posix/pair/api-activate/activate_demo.c
@@ -7,7 +7,8 @@
  *  1. Receive the pairing token from the caller (originally from OpenAPI).
  *  2. iot_client_init_on_boarding_with_token() -- activate device with token.
  *  3. iot_client_get_session_token() -- verify cloud connectivity.
- *  4. With --release: iot_client_reset() -- hand the binding back.
+ *  4. With --release: iot_client_reset(IOT_RESET_UNBIND_ONLY) -- hand the
+ *     binding back, keeping the cloud-side data.
  *
  * Step 4 is the other end of step 2. Activation and release are one lifecycle,
  * so they live in one demo: a device that binds itself must be able to unbind
@@ -123,7 +124,13 @@ int demo_activate_run(const char *token,
     if (release) {
         char error_code[64] = {0};
         printf("[%s] releasing the binding (device-initiated reset)...\n", TAG);
-        int rc = iot_client_reset(client, error_code, sizeof(error_code));
+        /* IOT_RESET_UNBIND_ONLY, not IOT_RESET_FACTORY: this demo gives the
+         * binding back and leaves the device's cloud-side data alone, so it can
+         * be run repeatedly. A real decommission -- device discarded or handed
+         * to a new owner -- passes IOT_RESET_FACTORY instead, which also
+         * discards that data and cannot be undone. */
+        int rc = iot_client_reset(client, IOT_RESET_UNBIND_ONLY,
+                                  error_code, sizeof(error_code));
         if (rc == OPRT_OK) {
             /* `client` is gone from here on. A real device would now wipe the
              * credentials and schema it persisted and re-enter pairing; this

--- a/modules/iot-client/include/iot_client.h
+++ b/modules/iot-client/include/iot_client.h
@@ -88,11 +88,35 @@ typedef void (*iot_message_callback_t)(const char *topic, size_t topic_len,
 
 /**
  * @brief Reset type classification (mirrors TuyaOpen TUYA_RESET_TYPE_REMOTE_*).
+ *
+ * Inbound only: how to read a device-remove the cloud pushed at us. The
+ * outbound choice -- what to ask the cloud for -- is iot_reset_scope_t.
  */
 typedef enum {
     IOT_RESET_REMOTE_UNBIND = 0,  // user removed the device (re-bind allowed)
     IOT_RESET_REMOTE_FACTORY,     // cloud-ordered factory reset
 } iot_reset_type_t;
+
+/**
+ * @brief How much to clear when this device resets itself (iot_client_reset).
+ *
+ * The outbound counterpart of iot_reset_type_t, and the same two meanings, but
+ * kept a separate type on purpose: those constants are named REMOTE_ because
+ * they describe a push the cloud initiated, which reads backwards on a call the
+ * device makes.
+ *
+ * An enum rather than a bool because the two differ in whether they can be
+ * undone, and a bare `true` at the call site would not say which one it is.
+ */
+typedef enum {
+    /* Drop the user-device binding only. The device's cloud-side data is kept,
+     * so re-pairing can pick it up again. Maps to resetFactory=false. */
+    IOT_RESET_UNBIND_ONLY = 0,
+    /* Factory reset: the cloud additionally discards the data it holds for this
+     * device (business-specific exclusions aside). NOT reversible -- re-pairing
+     * yields a new binding, not the old state. Maps to resetFactory=true. */
+    IOT_RESET_FACTORY,
+} iot_reset_scope_t;
 
 /**
  * @brief Callback fired when the cloud pushes a device-remove (protocol 11)
@@ -273,6 +297,17 @@ IOT_API iot_client_t *iot_client_init_on_boarding_with_token(const iot_on_boardi
  * iot_client_deinit() frees -- and @p client is invalid on return: do not use
  * or free it again.
  *
+ * @p scope decides how much the cloud clears, and the two options differ in
+ * whether they can be undone:
+ * - IOT_RESET_UNBIND_ONLY drops the user-device binding and leaves the device's
+ *   cloud-side data in place, so re-pairing can pick it up again.
+ * - IOT_RESET_FACTORY additionally discards everything the cloud holds for this
+ *   device, business-specific exclusions aside. THIS IS NOT REVERSIBLE:
+ *   re-pairing yields a new binding, not the old state.
+ *
+ * Either way this is not a way to "reconnect cleanly" or to recover from an
+ * error -- both give the binding up. For those, disconnect and connect again.
+ *
  * On failure NOTHING is destroyed: the client stays fully usable so the caller
  * can retry, or give up and call iot_client_deinit() itself. The return code is
  * therefore "does the cloud know", never "is the client still alive".
@@ -298,6 +333,9 @@ IOT_API iot_client_t *iot_client_init_on_boarding_with_token(const iot_on_boardi
  * alone cannot.
  *
  * @param client         Pointer to iot_client_t instance (must be activated)
+ * @param scope          How much to clear (see iot_reset_scope_t); pass
+ *                       IOT_RESET_UNBIND_ONLY unless the device is being
+ *                       decommissioned
  * @param error_code     Optional buffer receiving the cloud's errorCode; "" when
  *                       the cloud did not send one. NULL if not needed.
  *                       IOT_ATOP_ERROR_CODE_LEN bytes is always enough.
@@ -310,6 +348,7 @@ IOT_API iot_client_t *iot_client_init_on_boarding_with_token(const iot_on_boardi
  *         non-OPRT_OK case)
  */
 IOT_API int iot_client_reset(iot_client_t *client,
+                             iot_reset_scope_t scope,
                              char *error_code, size_t error_code_len);
 
 /**

--- a/modules/iot-client/src/iot_client.c
+++ b/modules/iot-client/src/iot_client.c
@@ -323,9 +323,10 @@ IOT_API void iot_client_deinit(iot_client_t *client)
  * it comes back as a cloud rejection that reads like a network fault. The mock
  * verifies this exact value so a slip fails in iot_reset_test. */
 #define IOT_ATOP_API_DEVICE_RESET         "tuya.device.reset"
-#define IOT_ATOP_API_DEVICE_RESET_VERSION "3.0"
+#define IOT_ATOP_API_DEVICE_RESET_VERSION "5.0"
 
 IOT_API int iot_client_reset(iot_client_t *client,
+                             iot_reset_scope_t scope,
                              char *error_code, size_t error_code_len)
 {
     if (error_code != NULL && error_code_len > 0) {
@@ -341,8 +342,17 @@ IOT_API int iot_client_reset(iot_client_t *client,
      * unlike a result-less named wrapper, it hands back the cloud's errorCode,
      * which is the one thing a caller needs to tell a terminal rejection from a
      * retryable one. */
-    char body[32];
-    int sn = snprintf(body, sizeof(body), "{\"t\":%" PRIu32 "}",
+    /* resetFactory picks between the cloud's two meanings for removing a device
+     * -- the same pair the inbound protocol-11 notice carries as
+     * IOT_RESET_REMOTE_FACTORY vs IOT_RESET_REMOTE_UNBIND. false gives up the
+     * binding and leaves the device's cloud-side data alone; true also discards
+     * that data, irreversibly. The field is required either way: omitting it is
+     * rejected, and the mock asserts its presence so that fails in
+     * iot_reset_test rather than as an opaque rejection on a device. */
+    char body[64];
+    int sn = snprintf(body, sizeof(body),
+                      "{\"resetFactory\":%s,\"t\":%" PRIu32 "}",
+                      (scope == IOT_RESET_FACTORY) ? "true" : "false",
                       (uint32_t)time(NULL));
     if (sn < 0 || (size_t)sn >= sizeof(body)) {
         return OPRT_COMMUNICATION_ERROR;

--- a/modules/iot-client/test/iot_reset_test.c
+++ b/modules/iot-client/test/iot_reset_test.c
@@ -173,8 +173,8 @@ static iot_client_t *make_client(const char *devid)
 
 static int test_null_client(void)
 {
-    if (iot_client_reset(NULL, NULL, 0) != OPRT_INVALID_PARAMETER) {
-        printf("  iot_client_reset(NULL, NULL, 0) must return OPRT_INVALID_PARAMETER\n");
+    if (iot_client_reset(NULL, IOT_RESET_UNBIND_ONLY, NULL, 0) != OPRT_INVALID_PARAMETER) {
+        printf("  iot_client_reset(NULL, IOT_RESET_UNBIND_ONLY, NULL, 0) must return OPRT_INVALID_PARAMETER\n");
         return -1;
     }
     return 0;
@@ -188,7 +188,7 @@ static int test_requires_device_credentials(void)
 
     iot_client_t *no_devid = make_client("");
     if (!no_devid) return -1;
-    if (iot_client_reset(no_devid, NULL, 0) != OPRT_UNINITIALIZED) {
+    if (iot_client_reset(no_devid, IOT_RESET_UNBIND_ONLY, NULL, 0) != OPRT_UNINITIALIZED) {
         printf("  empty devid must return OPRT_UNINITIALIZED\n");
         result = -1;
     }
@@ -202,7 +202,7 @@ static int test_requires_device_credentials(void)
     iot_client_t *no_key = make_client(TEST_DEVID);
     if (!no_key) return -1;
     no_key->secret_key[0] = '\0';
-    if (iot_client_reset(no_key, NULL, 0) != OPRT_UNINITIALIZED) {
+    if (iot_client_reset(no_key, IOT_RESET_UNBIND_ONLY, NULL, 0) != OPRT_UNINITIALIZED) {
         printf("  empty secret_key must return OPRT_UNINITIALIZED\n");
         result = -1;
     }
@@ -218,9 +218,11 @@ static int test_requires_device_credentials(void)
  * populated result -- an insistence on one would turn every success into an
  * error.
  *
- * This also pins the interface version: the mock rejects anything but v=3.0,
- * so a slip in ATOP_DEVICE_RESET_VERSION fails here rather than showing up as
- * an opaque cloud rejection on a real device.
+ * This also pins the interface version: the mock rejects anything but v=5.0, so
+ * an edit to the constant fails here rather than showing up as an opaque cloud
+ * rejection. Note the limit of that guarantee -- the mock only knows the value
+ * this repo told it, so it catches a change, not a wrong value. The pair is
+ * confirmed against the real cloud, which is where 3.0 was found to be wrong.
  *
  * The client is deliberately not touched or freed afterwards: it is gone, and
  * the leak checkers are what verify that. */
@@ -230,7 +232,7 @@ static int test_reset_success_destroys_client(void)
     if (!client) return -1;
 
     char error_code[64] = "unset";
-    int rc = iot_client_reset(client, error_code, sizeof(error_code));
+    int rc = iot_client_reset(client, IOT_RESET_UNBIND_ONLY, error_code, sizeof(error_code));
     if (error_code[0] != '\0') {
         printf("  errorCode should be empty on success, got \"%s\"\n", error_code);
     }
@@ -253,7 +255,7 @@ static int test_reset_failure_keeps_client(void)
 
     int result = 0;
     char error_code[64] = {0};
-    int rc = iot_client_reset(client, error_code, sizeof(error_code));
+    int rc = iot_client_reset(client, IOT_RESET_UNBIND_ONLY, error_code, sizeof(error_code));
     if (rc != OPRT_ATOP_BUSINESS_ERROR) {
         printf("  returned %d, expected OPRT_ATOP_BUSINESS_ERROR\n", rc);
         result = -1;
@@ -273,13 +275,42 @@ static int test_reset_failure_keeps_client(void)
         result = -1;
     }
     /* And retryable -- the same call again reaches the cloud again. */
-    if (iot_client_reset(client, NULL, 0) != OPRT_ATOP_BUSINESS_ERROR) {
+    if (iot_client_reset(client, IOT_RESET_UNBIND_ONLY, NULL, 0) != OPRT_ATOP_BUSINESS_ERROR) {
         printf("  client was not retryable after a failed reset\n");
         result = -1;
     }
 
     iot_client_deinit(client);   /* failure means teardown is still the caller's */
     return result;
+}
+
+/* IOT_RESET_FACTORY must actually put resetFactory=true on the wire.
+ *
+ * Nothing in the response can show it -- the interface answers with an empty
+ * result either way -- so the mock keys off the devId instead: one containing
+ * "factory" is required to present resetFactory=true, any other false. Sending
+ * the wrong scope is rejected as ILLEGAL_PARAM, which is what makes this test
+ * able to fail. The two scopes are not interchangeable: FACTORY discards the
+ * device's cloud-side data irreversibly, UNBIND_ONLY leaves it. */
+static int test_factory_scope_reaches_the_wire(void)
+{
+    iot_client_t *client = make_client("factory_device_test_01");
+    if (!client) return -1;
+
+    char error_code[64] = "unset";
+    int rc = iot_client_reset(client, IOT_RESET_FACTORY,
+                              error_code, sizeof(error_code));
+    if (rc != OPRT_OK) {
+        printf("  returned %d (errorCode=%s), expected OPRT_OK\n", rc, error_code);
+        iot_client_deinit(client);
+        return -1;
+    }
+    if (error_code[0] != '\0') {
+        printf("  errorCode should be empty on success, got \"%s\"\n", error_code);
+        return -1;   /* client already destroyed by the successful reset */
+    }
+    printf("  factory scope accepted; client released\n");
+    return 0;
 }
 
 int main(void)
@@ -308,6 +339,7 @@ int main(void)
 
     /* Round trips */
     RUN_TEST(test_reset_success_destroys_client);
+    RUN_TEST(test_factory_scope_reaches_the_wire);
     RUN_TEST(test_reset_failure_keeps_client);
 
     stop_mock_server();

--- a/modules/iot-client/test/mock/atop_mock.py
+++ b/modules/iot-client/test/mock/atop_mock.py
@@ -357,7 +357,7 @@ def handle_device_reset(request_data, config, url_params=None):
     test only has to vary the devid string.
     """
     try:
-        json.loads(request_data)
+        body = json.loads(request_data)
     except Exception as e:
         print(f"\u274c device reset: unparsable body: {e}", file=sys.stderr)
         return json.dumps({
@@ -367,18 +367,53 @@ def handle_device_reset(request_data, config, url_params=None):
             "errorMsg": str(e)
         }, separators=(',', ':'))
 
+    # resetFactory is required, and both values are legal: false unbinds, true
+    # also wipes the device's cloud-side data. Pin its PRESENCE (omitting it
+    # would come back from the real cloud as an opaque rejection -- the same
+    # class of late failure as a wrong version below) and echo it back, so a
+    # test can prove the caller's choice actually reached the wire.
+    reset_factory = body.get('resetFactory')
+    if not isinstance(reset_factory, bool):
+        print(f"\u274c device reset: resetFactory missing or not a bool: {body!r}",
+              file=sys.stderr)
+        return json.dumps({
+            "success": False,
+            "t": int(time.time()),
+            "errorCode": "ILLEGAL_PARAM",
+            "errorMsg": "tuya.device.reset expects a boolean resetFactory"
+        }, separators=(',', ':'))
+    print(f"   resetFactory: {reset_factory}")
+
+    # The caller's scope has to reach the wire, and an empty-result response
+    # cannot show which one arrived. Encode the expectation in the devId
+    # instead: a devId containing 'factory' must present resetFactory=true, any
+    # other must present false. A test that sends the wrong scope is then
+    # rejected here rather than passing silently -- and the success response
+    # keeps the empty result the real interface returns.
+    devid_for_scope = (url_params or {}).get('devId', '')
+    expect_factory = 'factory' in devid_for_scope
+    if reset_factory is not expect_factory:
+        print(f"\u274c device reset: devId {devid_for_scope!r} expects "
+              f"resetFactory={expect_factory}, got {reset_factory}", file=sys.stderr)
+        return json.dumps({
+            "success": False,
+            "t": int(time.time()),
+            "errorCode": "ILLEGAL_PARAM",
+            "errorMsg": f"expected resetFactory={str(expect_factory).lower()}"
+        }, separators=(',', ':'))
+
     # Pin the interface version. It is the one thing about this call that a
     # local test cannot otherwise check: on a real device a wrong version comes
     # back as an opaque cloud rejection, which reads like a network fault.
     version = (url_params or {}).get('v', '')
-    if version != '3.0':
-        print(f"\u274c device reset: wrong interface version {version!r} (expected '3.0')",
+    if version != '5.0':
+        print(f"\u274c device reset: wrong interface version {version!r} (expected '5.0')",
               file=sys.stderr)
         return json.dumps({
             "success": False,
             "t": int(time.time()),
             "errorCode": "UNKNOWN_API_VERSION",
-            "errorMsg": f"tuya.device.reset expects v=3.0, got {version!r}"
+            "errorMsg": f"tuya.device.reset expects v=5.0, got {version!r}"
         }, separators=(',', ':'))
 
     devid = (url_params or {}).get('devId', '')


### PR DESCRIPTION
The request body was `{"t":…}` only. tuya.device.reset requires resetFactory, so the call as shipped came back rejected -- and rejected in the way that reads like a network fault rather than a missing field, since the return code alone says nothing about which parameter the cloud objected to.

The field is not a formality: it picks between the cloud's two meanings for removing a device, and they differ in whether they can be undone. New iot_reset_scope_t makes that the caller's decision:

  IOT_RESET_UNBIND_ONLY (false) -- give up the user-device binding, leave the
      device's cloud-side data in place. Re-pairing can pick it up again.
  IOT_RESET_FACTORY (true) -- also discard the data the cloud holds for this
      device, business-specific exclusions aside. NOT reversible: re-pairing
      yields a new binding, not the old state.

Same pair of meanings the inbound protocol-11 notice already carries, in the opposite direction -- which is why this is a separate type rather than a reuse of iot_reset_type_t: those constants are named REMOTE_ because they describe a push the cloud initiated, and read backwards on a call the device makes. An enum rather than a bool because a bare `true` at the call site would not say which one it is, and picking the wrong one cannot be walked back.

Neither scope is a way to reconnect cleanly or recover from an error -- both give the binding up. The header and reference doc say so and point at disconnect/connect instead.

The interface version is 5.0. A first attempt used 3.0 and the cloud answered API_OR_API_VERSION_WRONG on a real device -- an error that does not even say whether the name or the version was at fault. Worth recording because it marks the limit of the mock's version pin: the mock only knows the value this repo told it, so it catches an edit to the constant, not a wrong constant. Only the cloud can confirm the pair, and the test comment now says so.

The mock also requires resetFactory and pins the choice, because nothing in the response can show it: the interface answers with an empty result either way. A devId containing "factory" must arrive with resetFactory=true, any other with false, so a scope that fails to reach the wire is rejected instead of passing silently. Verified by inverting the mapping -- iot_reset_test drops to 2/5. The success envelope still returns an empty result, matching the real interface, which is itself something the suite asserts.

api-activate --release passes IOT_RESET_UNBIND_ONLY so the demo can be re-run; its comment names what a real decommission would pass instead.

Verified: full build clean; ctest --timeout 180 14/14; iot_reset_test 5/5 (1 new); activate_demo builds against the new signature. The api/version pair itself is not verified by any of that -- it needs a real device.