### PR TITLE
fix(iot-client): point the UEAZ ATOP fallback at a host that exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,8 +192,9 @@ ordinary changes.
   switches end in `default:`, so `-Wswitch` never fires and a miss succeeds at the HTTP layer
   against a real, wrong data center; `dns_test.c` asserts only the PROD arm. Measured facts no
   file in the repo records (probed 2026-08-14): `SG` is absent from the PRE arm because it does
-  not exist in pre; `IOT_UEAZ_HOST` (`a1-ueaz.tuyaeu.com`) is **NXDOMAIN** — UE lives under
-  `tuyaus.com`, so the UE ATOP fallback path is dead; and on prod West-Europe's `httpsUrl` *flaps*
+  not exist in pre; `IOT_UEAZ_HOST` shipped as `a1-ueaz.tuyaeu.com`, which is **NXDOMAIN** — UE
+  lives under `tuyaus.com`, so the UE ATOP fallback was dead until it was repointed at
+  `a1-ueaz.tuyaus.com` (2026-08-31); and on prod West-Europe's `httpsUrl` *flaps*
   rather than being absent, so the device alternates between the DNS answer and the compile-time
   fallback across reboots.
 - **`OPRT_OK` from `atop_base_request()` means `success == true`, nothing more.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- iot-client — US-East (`UEAZ`) fell back to an ATOP host that does not resolve(#32).
+  `IOT_UEAZ_HOST` is now `a1-ueaz.tuyaus.com`.
+
 ## [0.4.0] - 2026-08-27
 
 ### Added

--- a/modules/iot-client/src/iot_config_defaults.h
+++ b/modules/iot-client/src/iot_config_defaults.h
@@ -25,7 +25,7 @@
 #define IOT_CN_PRE_HOST "a1-cn.wgine.com"
 #define IOT_AZ_HOST "a1.tuyaus.com"
 #define IOT_AZ_PRE_HOST "a1-us.wgine.com"
-#define IOT_UEAZ_HOST "a1-ueaz.tuyaeu.com"
+#define IOT_UEAZ_HOST "a1-ueaz.tuyaus.com"
 #define IOT_UEAZ_PRE_HOST "a1-ueaz.wgine.com"
 #define IOT_EU_HOST "a1.tuyaeu.com"
 #define IOT_EU_PRE_HOST "a1-eu.wgine.com"


### PR DESCRIPTION
IOT_UEAZ_HOST shipped as a1-ueaz.tuyaeu.com, which is NXDOMAIN — US-East lives under tuyaus.com, not tuyaeu.com. The name has never resolved, so the whole US-East ATOP fallback path was dead: whenever IoT-DNS answered POST /v2/url_config without an httpsUrl, iot_region_to_host(UEAZ, PROD) handed back a name no resolver can answer and the device had nowhere to go. The sibling constants show what the intent was — IOT_AZ_HOST is a1.tuyaus.com and IOT_UEAZ_PRE_HOST is a1-ueaz.wgine.com; only the prod UE entry drifted into the EU domain, and it has been wrong since the initial commit.

Probed 2026-08-31: a1-ueaz.tuyaeu.com NXDOMAIN, a1-ueaz.tuyaus.com resolves to 35.212.96.105. a1-ueaz.wgine.com resolves too, but to 100.64.3.152 — RFC 6598 shared address space, reachable only from inside Tuya, which is right for the PRE constant and wrong for PROD.

Nothing asserts the constant's value: dns_test.c's PROD mapping test compares iot_region_to_host() against IOT_UEAZ_HOST itself, so it passes either way. That is deliberate — the test guards against a region falling through to the China default, not against a typo in the host — and a test pinning the literal would just restate the header. The failure is only visible against real DNS, which is why AGENTS.md carries the measured facts; its UEAZ note is updated here to say the name was repointed rather than that the path is still dead.

Verified: full ctest suite 15/15 on a clean worktree carrying only this commit.