### PR TITLE
feat(rtc-tcp-client): add TCP backpressure via on_flow_control hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- rtc-tcp-client — enforce receive backpressure between buffered Frames and drain reads; resume buffered data without another network read (PR pending).
+
 - iot-client — US-East (`UEAZ`) fell back to an ATOP host that does not resolve(#31).
   `IOT_UEAZ_HOST` is now `a1-ueaz.tuyaus.com`.
 

--- a/modules/rtc-tcp-client/include/tuya_ai.h
+++ b/modules/rtc-tcp-client/include/tuya_ai.h
@@ -328,6 +328,18 @@ typedef struct tai_config {
     void (*on_disconnect)(tai_ctx_t *ctx, const tai_disconnect_msg_t *msg, void *user_data);
     void *user_data;
 
+    /* Optional TCP-level flow control. Called on the worker thread before each
+     * recv and between buffered frames (not during the connect handshake).
+     * Return 1 to receive normally; return 0 to pause parsing and SKIP the read
+     * for this pass, which lets the lwIP receive window close and stalls the
+     * sender (standard TCP backpressure). While returning 0 the control channel
+     * (CHAT_BREAK, ASR text) is also stalled — accept that tradeoff deliberately.
+     * Buffered frames resume without requiring new network data. A single
+     * dispatched packet may contain multiple audio codec frames; applications
+     * must also bound admission within their audio callback.
+     * NULL = always read (no backpressure). */
+    int  (*on_flow_control)(tai_ctx_t *ctx, void *user_data);
+
 } tai_config_t;
 
 /* =========================================================================

--- a/modules/rtc-tcp-client/src/tai_client.c
+++ b/modules/rtc-tcp-client/src/tai_client.c
@@ -338,6 +338,7 @@ tai_ctx_t *tai_ctx_init(void *mem, const tai_config_t *cfg)
     ctx->on_image              = cfg->on_image;
     ctx->on_event              = cfg->on_event;
     ctx->on_disconnect         = cfg->on_disconnect;
+    ctx->on_flow_control       = cfg->on_flow_control;
     ctx->user_data             = cfg->user_data;
 
     ctx->ping_interval_ms  = cfg->ping_interval_ms  ? cfg->ping_interval_ms  : 60000U;
@@ -719,6 +720,11 @@ static int tai_process_rx(tai_ctx_t *ctx)
      * by dropping bytes/frames, so we RETURN the cause and let the worker tear
      * the connection down (the app reconnects). */
     while (ctx->rx_len >= 5) {
+        /* A single recv can contain multiple frames. Leave unconsumed bytes
+         * in rx_buf when the application fills up during dispatch. */
+        if (!ctx->connecting && ctx->on_flow_control &&
+            !ctx->on_flow_control(ctx, ctx->user_data))
+            break;
         /* Detect version from first byte */
         int ver = tai_frame_detect_version(ctx->rx_buf[0]);
         if (ver < 0) {
@@ -1234,6 +1240,15 @@ static void *worker_thread(void *arg)
     tai_ctx_t *ctx = (tai_ctx_t *)arg;
     TAI_LOGD(ctx->pal, TAG, "worker: started");
 
+    /* Yield the CPU for yield_ms without touching any socket. The PAL has no
+     * sleep primitive; tcp_poll with events=0 maps to select(nfds, NULL, NULL,
+     * NULL, &tv) — a pure timed block. Any connected handle works; we reuse the
+     * live TLS/TCP handle. Essential on single-core targets where a busy worker
+     * would otherwise starve the IDLE task and trip the task watchdog. */
+    void *yield_tcp = ctx->tls ? tls_get_tcp_handle(ctx->tls) : ctx->raw_tcp;
+    #define worker_yield(ms) \
+        do { if (yield_tcp) ctx->pal->tcp_poll(yield_tcp, 0, (ms)); } while (0)
+
     /* The worker owns the disconnect decision: lower layers RETURN a fatal
      * cause, transport faults are detected here, and we fire on_disconnect once
      * on exit. f_reason==0xFF means a clean stop (tai_disconnect / request). */
@@ -1289,8 +1304,26 @@ static void *worker_thread(void *arg)
          * ~TAI_WORKER_POLL_CAP_MS instead of waiting out a whole ping interval. */
         if (wait_ms > TAI_WORKER_POLL_CAP_MS) wait_ms = TAI_WORKER_POLL_CAP_MS;
 
+        /* TCP-level flow control: when the downstream decoder queue is full the
+         * app's on_flow_control hook returns 0. Skip the socket read entirely so
+         * lwIP's receive buffer stays full and its advertised TCP window shrinks
+         * to 0, stalling the sender (standard TCP backpressure). While stalled,
+         * inbound control frames (CHAT_BREAK) are also blocked — the app accepts
+         * that tradeoff by installing the hook. We still run ping/liveness above
+         * and re-check every TAI_FLOW_CONTROL_POLL_MS. */
+        if (ctx->on_flow_control && !ctx->on_flow_control(ctx, ctx->user_data)) {
+            /* Block ~TAI_FLOW_CONTROL_POLL_MS WITHOUT reading, then re-check the
+             * hook. The zero-event poll is a genuine CPU yield (see worker_yield),
+             * so IDLE runs and the watchdog resets while the lwIP receive window
+             * stays closed (TCP backpressure). */
+            worker_yield(TAI_FLOW_CONTROL_POLL_MS);
+            continue;
+        }
+
         uint64_t drain_start = ctx->pal->time_ms();
-        int n = tai_recv_data(ctx, wait_ms);
+        /* Resume buffered frames before reading again; otherwise flow control
+         * could leave a complete frame stranded until more network data arrives. */
+        int n = ctx->rx_len ? (int)ctx->rx_len : tai_recv_data(ctx, wait_ms);
         while (n > 0 && ctx->running) {
             int fatal = tai_process_rx(ctx);
             if (fatal != TAI_OK) {
@@ -1308,6 +1341,13 @@ static void *worker_thread(void *arg)
              * the next pass. */
             if (ctx->pal->time_ms() - drain_start > TAI_DRAIN_BUDGET_MS)
                 break;
+            /* Recheck after every dispatch, including the greedy drain path. */
+            if (ctx->on_flow_control && !ctx->on_flow_control(ctx, ctx->user_data))
+                break;
+            /* Yield inside the greedy drain: under a flood the non-blocking recv
+             * below returns immediately every pass, so without this the drain is
+             * a tight loop that starves the IDLE task on single-core targets. */
+            worker_yield(TAI_WORKER_YIELD_MS);
             n = tai_recv_data(ctx, 0);   /* drain remainder non-blocking */
         }
         if (f_reason != 0xFF) break;     /* fail-fast / CONNECTION_CLOSE during drain */
@@ -1327,6 +1367,12 @@ static void *worker_thread(void *arg)
         /* n > 0: budget yield (running still set) -> loop, keep housekeeping.
          * n == TAI_ERR_AGAIN: wait timed out (ping due) or drain finished.
          * running cleared with no fatal: a clean tai_request_disconnect. */
+
+        /* Yield at the end of every iteration. When data is flowing the blocking
+         * recv above returns immediately, so the loop body is otherwise a tight
+         * CPU-bound cycle; this guarantees the IDLE task a slice on single-core
+         * targets (ESP32-C3) and keeps the task watchdog happy under a TTS flood. */
+        worker_yield(TAI_WORKER_YIELD_MS);
     }
 
     /* Single-point disconnect: fire on_disconnect exactly once if the worker
@@ -1340,5 +1386,6 @@ static void *worker_thread(void *arg)
     }
 
     TAI_LOGD(ctx->pal, TAG, "worker: exiting");
+    #undef worker_yield
     return NULL;
 }

--- a/modules/rtc-tcp-client/src/tai_internal.h
+++ b/modules/rtc-tcp-client/src/tai_internal.h
@@ -158,6 +158,23 @@
 #  define TAI_WORKER_POLL_CAP_MS  2000U
 #endif
 
+/* Dwell between flow-control re-checks when the app's on_flow_control hook
+ * reports the downstream decoder queue full. Each pass polls (not reads) the
+ * socket for this many ms, so the hook is re-evaluated at ~1000/x Hz and the
+ * lwIP receive window stays closed (TCP backpressure) in between. */
+#ifndef TAI_FLOW_CONTROL_POLL_MS
+#  define TAI_FLOW_CONTROL_POLL_MS  50U
+#endif
+
+/* Per-iteration CPU yield (ms). On single-core targets (ESP32-C3) the worker
+ * can otherwise monopolise the CPU under a sustained TTS flood: each recv()
+ * returns immediately (data is waiting) and the greedy drain loops with no
+ * blocking point, starving the IDLE task and tripping the task watchdog. A
+ * short sleep each pass guarantees IDLE a slice so the watchdog resets. */
+#ifndef TAI_WORKER_YIELD_MS
+#  define TAI_WORKER_YIELD_MS  10U
+#endif
+
 
 /* =========================================================================
  * Attribute type codes  (Appendix A)
@@ -313,6 +330,9 @@ struct tai_ctx {
     void (*on_event)     (tai_ctx_t *, const tai_event_msg_t      *, void *);
     void (*on_disconnect)(tai_ctx_t *, const tai_disconnect_msg_t *, void *);
     void *user_data;
+
+    /* Optional TCP-level flow control (see tuya_ai.h). NULL = always read. */
+    int (*on_flow_control)(tai_ctx_t *, void *);
 
     /* RX linear buffer (sliding-window: bytes always at buf[0]) */
     uint8_t rx_buf[TAI_RX_BUF_SIZE];

--- a/modules/rtc-tcp-client/test/test_integration.c
+++ b/modules/rtc-tcp-client/test/test_integration.c
@@ -2021,6 +2021,58 @@ static void test_disconnect_latency(void)
     tai_ctx_deinit(ctx);
 }
 
+/* Pause after each delivered packet, including packets coalesced in one recv.
+ * Resume without pushing new network bytes to detect stranded rx_buf data. */
+static int flow_allowed_calls;
+static int test_flow_control(tai_ctx_t *ctx, void *user)
+{
+    (void)ctx; (void)user;
+    pthread_mutex_lock(&g_st.mtx);
+    int ready = g_st.audio_calls < flow_allowed_calls;
+    pthread_mutex_unlock(&g_st.mtx);
+    return ready;
+}
+
+static void test_receive_backpressure(void)
+{
+    SECTION("receive_backpressure");
+    static uint8_t mem[sizeof(struct tai_ctx)];
+    tai_ctx_t *ctx = setup_ctx(mem);
+    flow_allowed_calls = 0;
+    ctx->on_flow_control = test_flow_control;
+    CHECK_EQ_INT(tai_connect(ctx), TAI_OK);
+    uint8_t audio[800];
+    memset(audio, 0x5a, sizeof(audio));
+    for (int i = 0; i < 40; ++i)
+        CHECK(server_send_audio(ctx, i == 0 ? TAI_STREAM_START : TAI_STREAM_MIDDLE,
+                                i == 0 ? "111 1 16 16000" : NULL,
+                                audio, sizeof(audio), (uint16_t)(100+i)) > 0);
+    for (int allowed = 1; allowed <= 40; ++allowed) {
+        pthread_mutex_lock(&g_st.mtx);
+        flow_allowed_calls = allowed;
+        pthread_mutex_unlock(&g_st.mtx);
+        int delivered = 0;
+        for (int attempt = 0; attempt < 200; ++attempt) {
+            sleep_ms(5);
+            pthread_mutex_lock(&g_st.mtx);
+            delivered = g_st.audio_calls;
+            pthread_mutex_unlock(&g_st.mtx);
+            if (delivered >= allowed) break;
+        }
+        /* Allow the greedy drain to run while admission remains closed. */
+        sleep_ms(10);
+        pthread_mutex_lock(&g_st.mtx);
+        CHECK_EQ_INT(g_st.audio_calls, allowed);
+        pthread_mutex_unlock(&g_st.mtx);
+        if (delivered != allowed) break;
+    }
+    tai_disconnect(ctx);  /* Must also shut down while flow is paused. */
+    CHECK_EQ_INT(g_st.audio_calls, 40);
+    CHECK_EQ_INT(g_st.audio_bytes, 40 * sizeof(audio));
+    CHECK_EQ_INT(g_st.disconnect_calls, 0);
+    tai_ctx_deinit(ctx);
+}
+
 /* =========================================================================
  * main
  * ========================================================================= */
@@ -2029,6 +2081,7 @@ int main(void)
     printf("=== Tuya AI -- integration tests (loopback PAL) ===\n");
     pthread_mutex_init(&g_st.mtx, NULL);
 
+    test_receive_backpressure();
     test_text_query();
     test_audio_roundtrip();
     test_image_query();


### PR DESCRIPTION
The worker calls the app's on_flow_control hook before each recv and between buffered frames; when it returns 0 the read is skipped so the lwIP receive window closes and stalls the sender. Buffered frames resume without requiring new network data. Add worker_yield (zero-event tcp_poll) so single-core targets (ESP32-C3) cannot starve the IDLE task and trip the task watchdog under a TTS flood. New knobs: TAI_FLOW_CONTROL_POLL_MS and TAI_WORKER_YIELD_MS. Integration test covers per-packet pause, resume without new bytes, and disconnect while paused.